### PR TITLE
Enabled strict-boolean-expressions

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -209,7 +209,7 @@
             "never"
         ],
         "strict-boolean-expressions": [
-          false,
+          true,
           "allow-null-union",
           "allow-undefined-union"
         ],


### PR DESCRIPTION
- We are using the rule with configuration as 
```
"strict-boolean-expressions": [
          false,
          "allow-null-union",
          "allow-undefined-union"
        ]
```
- Rule definition here: https://palantir.github.io/tslint/rules/strict-boolean-expressions/
- `false` means rule is turned off.
- Here, when we perform logical OR or logical AND operation on numbers or strings, it leads to possibly wrong results.
- E.g. `const selectedIndex = this.props.selectedIndex ||  -1;` leads to value `-1` in case of `selectedIndex` as 0, where as it was supposed to check only for `undefined` case of `selectedIndex`. 
- This was fixed by using `lodash`'s `get` function.
- Turning on this rule leads to a bunch of `tslint` errors in the code that we need to clean.
- It is allowed to apply boolean operations on optional `functions` or optional `objects`, even though it is safer or recommended to use `get` from `lodash.`
