### PR TITLE
CI: make sure version has changed compared to master branch

### DIFF
--- a/ci-test-clean-build.sh
+++ b/ci-test-clean-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -xe
+
+npm run build
+git diff --exit-code || (echo "git workspace not clean after npm run build" && exit 1)

--- a/ci-test-master-version.sh
+++ b/ci-test-master-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# there shouldn't be a diff, otherwise checking out package.json from master is not safe
+git diff --exit-code > /dev/null || (echo "git workspace not clean, aborting" && exit 1)
+
+CURR_BRANCH=`(git symbolic-ref --short HEAD)`
+if [[ "master" = "$CURR_BRANCH" ]]
+then
+  echo "current branch is master, not checking" && exit 0
+fi
+echo "current branch is $CURR_BRANCH"
+CURR_VERSION=`(node -p 'require("./package.json").version')`
+echo "current branch '$CURR_BRANCH' is at version '$CURR_VERSION'"
+
+git checkout origin/master -- package.json
+MASTER_VERSION=`(node -p 'require("./package.json").version')`
+git checkout HEAD -- package.json
+echo "master branch is at version '$MASTER_VERSION'"
+if [[ "$CURR_VERSION" = "$MASTER_VERSION" ]]
+then
+  echo "Error: Current branch has same version as master, you need to increase it before merging."
+  exit 2
+fi
+echo "all good: current branch has version different from master"

--- a/ci-test-master-version.sh
+++ b/ci-test-master-version.sh
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-# there shouldn't be a diff, otherwise checking out package.json from master is not safe
-git diff --exit-code > /dev/null || (echo "git workspace not clean, aborting" && exit 1)
-
 CURR_BRANCH=`(git symbolic-ref --short HEAD)`
 if [[ "master" = "$CURR_BRANCH" ]]
 then
   echo "current branch is master, not checking" && exit 0
 fi
-echo "current branch is $CURR_BRANCH"
-CURR_VERSION=`(node -p 'require("./package.json").version')`
+#echo "current branch is $CURR_BRANCH"
+CURR_VERSION=`(node -p "($(cat ./package.json)).version")`
 echo "current branch '$CURR_BRANCH' is at version '$CURR_VERSION'"
 
-git checkout origin/master -- package.json
-MASTER_VERSION=`(node -p 'require("./package.json").version')`
-git checkout HEAD -- package.json
+MASTER_VERSION=`(node -p "($(git show origin/master:package.json)).version")`
 echo "master branch is at version '$MASTER_VERSION'"
 if [[ "$CURR_VERSION" = "$MASTER_VERSION" ]]
 then

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ test:
   override:
     - npm test
   post:
-    - npm run build
-#    after build there shouldn't be a diff, otherwise dist folder is not in sync
-    - git diff --exit-code
+    - ./ci-test-clean-build.sh
+# ci-test-master-version.sh will abort in case of changes in working directory
+# so we do `git checkout HEAD` to reset working directory:
+# in case previous tests produced changes, we still execute the check instead of swallowing error
+    - git checkout HEAD && ./ci-test-master-version.sh

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,4 @@ test:
     - npm test
   post:
     - ./ci-test-clean-build.sh
-# ci-test-master-version.sh will abort in case of changes in working directory
-# so we do `git checkout HEAD` to reset working directory:
-# in case previous tests produced changes, we still execute the check instead of swallowing error
-    - git checkout HEAD && ./ci-test-master-version.sh
+    - ./ci-test-master-version.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "default tslint rules to use for projects using typescript",
   "main": "tslint.json",
   "files": [


### PR DESCRIPTION
I was thinking that we might want to make sure the version is increased during merges to master.
You can look at [the failed CircleCI build](https://circleci.com/gh/bettermarks/bm-tslint-rules/6) to see how this would look like.

Thank you @yever for finding out how to do this without `git checkout`