### PR TITLE
adding generated rule reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",

--- a/tslint.report.active.json
+++ b/tslint.report.active.json
@@ -1,0 +1,754 @@
+{
+  "adjacent-overload-signatures": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "align": {
+    "ruleArguments": [
+      "parameters",
+      "arguments",
+      "statements"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "array-bracket-spacing": {
+    "ruleArguments": [
+      "never"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "array-type": {
+    "ruleArguments": [
+      "array"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "arrow-return-shorthand": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "await-promise": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "ban": {
+    "ruleArguments": [
+      [
+        "alert"
+      ]
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "ban-types": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "brace-style": {
+    "ruleArguments": [
+      "1tbs",
+      {
+        "allowSingleLine": false
+      }
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "callable-types": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "chai-prefer-contains-to-index-of": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "class-name": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "comment-format": {
+    "ruleArguments": [
+      "check-space"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "cyclomatic-complexity": {
+    "ruleArguments": [
+      9
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "eofline": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "forin": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "handle-callback-err": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "import-spacing": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "indent": {
+    "ruleArguments": [
+      "spaces"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "jquery-deferred-must-complete": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "jsx-equals-spacing": {
+    "ruleArguments": [
+      "never"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "jsx-key": {
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "jsx-no-bind": {
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "jsx-no-string-ref": {
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "jsx-self-close": {
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "jsx-wrap-multiline": {
+    "ruleSeverity": "error",
+    "source": "tslint-react"
+  },
+  "label-position": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "linebreak-style": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "max-line-length": {
+    "ruleArguments": [
+      100
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "mocha-avoid-only": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "mocha-no-side-effect-code": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "mocha-unneeded-done": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "new-parens": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-absolute-import-to-own-parent": {
+    "ruleSeverity": "error",
+    "source": "bm-tslint-rules"
+  },
+  "no-angle-bracket-type-assertion": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-arg": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-banned-terms": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-bitwise": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-boolean-literal-compare": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-conditional-assignment": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-consecutive-blank-lines": {
+    "ruleArguments": [
+      3
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-constant-condition": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-constant-condition"
+    ]
+  },
+  "no-construct": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-control-regex": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-control-regex"
+    ]
+  },
+  "no-cookies": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-debugger": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-delete-expression": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-disable-auto-sanitization": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-document-domain": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-document-write": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-duplicate-case": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-duplicate-case"
+    ]
+  },
+  "no-duplicate-super": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-duplicate-variable": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-empty": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-empty-character-class": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-empty-interface": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-eval": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-ex-assign": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-exec-script": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-extra-boolean-cast": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-extra-semi": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-floating-promises": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-for-in": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-for-in-array": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-function-constructor-with-string-args": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-function-expression": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-import-side-effect": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-inferrable-types": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-inner-declarations": {
+    "ruleArguments": [
+      "both"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-inner-html": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-internal-module": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-invalid-regexp": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-invalid-regexp"
+    ]
+  },
+  "no-invalid-template-strings": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-invalid-this": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-irregular-whitespace": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-jquery-raw-elements": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-misused-new": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-multi-spaces": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "no-non-null-assertion": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-octal-literal": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-reference": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-reference-import": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-regex-spaces": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-regex-spaces"
+    ]
+  },
+  "no-sparse-arrays": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-stateless-class": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-immediate": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-interval": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-timeout": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-literal": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-string-throw": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-switch-case-fall-through": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-trailing-whitespace": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-typeof-undefined": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-bind": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-callback-wrapper": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-unnecessary-field-initialization": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-initializer": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-unnecessary-local-variable": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-override": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-qualifier": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-unnecessary-semicolons": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unsafe-finally": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-unsupported-browser-code": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unused-expression-chai": {
+    "ruleArguments": [
+      "allow-fast-null-checks"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-no-unused-expression-chai"
+  },
+  "no-unused-variable": {
+    "ruleArguments": [
+      "react"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-use-before-declare": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-useless-files": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-var-requires": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "no-var-self": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-with-statement": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "non-literal-require": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "object-curly-spacing": {
+    "ruleArguments": [
+      "never"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "object-literal-key-quotes": {
+    "ruleArguments": [
+      "as-needed"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "one-line": {
+    "ruleArguments": [
+      "check-open-brace",
+      "check-whitespace"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "possible-timing-attack": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "prefer-array-literal": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "prefer-const": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "prefer-for-of": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "prefer-template": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "promise-function-async": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "promise-must-complete": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "quotemark": {
+    "ruleArguments": [
+      "single",
+      "avoid-escape"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "radix": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "react-a11y-anchors": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-aria-unsupported-elements": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-event-has-role": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-image-button-has-alt": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-img-has-alt": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-lang": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-meta": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-props": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-proptypes": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role-has-required-aria-props": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role-supports-aria-props": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-tabindex-no-positive": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-titles": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-anchor-blank-noopener": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-iframe-missing-sandbox": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-no-dangerous-html": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-this-binding-issue": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-unused-props-and-state": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "semicolon": {
+    "ruleArguments": [
+      "always"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "space-before-function-paren": {
+    "ruleArguments": [
+      {
+        "anonymous": "always",
+        "named": "never",
+        "asyncArrow": "always",
+        "method": "never",
+        "constructor": "never"
+      }
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "space-in-parens": {
+    "ruleArguments": [
+      "never"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "switch-default": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "ter-arrow-spacing": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-indent": {
+    "ruleArguments": [
+      2,
+      {
+        "SwitchCase": true
+      }
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules"
+  },
+  "trailing-comma": {
+    "ruleArguments": [
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "triple-equals": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "typedef-whitespace": {
+    "ruleArguments": [
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "underscore-consistent-invocation": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "unified-signatures": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "use-isnan": {
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
+  "use-named-parameter": {
+    "ruleSeverity": "error",
+    "source": "tslint-microsoft-contrib"
+  },
+  "valid-typeof": {
+    "ruleSeverity": "error",
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:valid-typeof"
+    ]
+  },
+  "whitespace": {
+    "ruleArguments": [
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "ruleSeverity": "error",
+    "source": "tslint"
+  }
+}

--- a/tslint.report.available.json
+++ b/tslint.report.available.json
@@ -1,0 +1,5606 @@
+{
+  "./node_modules/tslint-microsoft-contrib:no-constant-condition": {
+    "type": "maintainability",
+    "description": "Do not use constant expressions in conditions.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 570, 571, 670",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:no-control-regex": {
+    "type": "maintainability",
+    "description": "Do not use control characters in regular expressions",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:no-duplicate-case": {
+    "type": "maintainability",
+    "description": "Do not use duplicate case labels in switch statements.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:no-invalid-regexp": {
+    "type": "maintainability",
+    "description": "Do not use invalid regular expression strings in the RegExp constructor.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:no-regex-spaces": {
+    "type": "maintainability",
+    "description": "Do not use multiple spaces in a regular expression literal. Similar to the ESLint no-regex-spaces rule",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:use-isnan": {
+    "type": "maintainability",
+    "description": "enforces that you use the isNaN() function to check for NaN references instead of a comparison to the NaN constant.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Ignored",
+    "source": "tslint-microsoft-contrib"
+  },
+  "./node_modules/tslint-microsoft-contrib:valid-typeof": {
+    "type": "maintainability",
+    "description": "Ensures that the results of typeof are compared against a valid string.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "adjacent-overload-signatures": {
+    "description": "Enforces function overloads to be consecutive.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "rationale": "Improves readability and organization by grouping naturally related items together.",
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "align": {
+    "description": "Enforces vertical alignment.",
+    "hasFix": true,
+    "rationale": "Helps maintain a readable, consistent style in your codebase.",
+    "optionsDescription": "\nFive arguments may be optionally provided:\n\n* `\"parameters\"` checks alignment of function parameters.\n* `\"arguments\"` checks alignment of function call arguments.\n* `\"statements\"` checks alignment of statements.\n* `\"members\"` checks alignment of members of classes, interfaces, type literal, object literals and\nobject destructuring.\n* `\"elements\"` checks alignment of elements of array iterals, array destructuring and tuple types.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "arguments",
+          "elements",
+          "members",
+          "parameters",
+          "statements"
+        ]
+      },
+      "minLength": 1,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      [
+        true,
+        "parameters",
+        "statements"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "array-bracket-spacing": {
+    "description": "enforce consistent spacing inside array brackets",
+    "rationale": "\nA number of style guides require or disallow spaces between array brackets and other tokens.\nThis rule applies to both array literals and destructuring assignments (ECMAScript 6).\n",
+    "optionsDescription": "\nThe rule takes one or two options. The first is a string, which can be:\n\n- `\"never\"` (default) disallows spaces inside array brackets\n- `\"always\"`requires one or more spaces or newlines inside array brackets\n\nThe second option is an object for exceptions to the `\"never\"` option:\n\n- `\"singleValue\": true` requires one or more spaces or newlines inside brackets of array\n                          literals that contain a single element\n- `\"objectsInArrays\": true` requires one or more spaces or newlines between brackets of\n                              array literals and braces of their object literal elements\n                              `[ {` or `} ]`\n- `\"arraysInArrays\": true` requires one or more spaces or newlines between brackets of\n                             array literals and brackets of their array literal elements\n                             `[ [` or `] ]`\n\nWhen using the `\"always\"` option the second option takes on these exceptions:\n\n- `\"singleValue\": false` disallows spaces inside brackets of array literals that contain a\n                           single element\n- `\"objectsInArrays\": false` disallows spaces between brackets of array literals and braces\n                               of their object literal elements `[ {` or `} ]`\n- `\"arraysInArrays\": false` disallows spaces between brackets of array literals and brackets\n                              of their array literal elements `[ [` or `] ]`\n\nThis rule has build-in exceptions:\n\n- `\"never\"` (and also the exceptions to the `\"always\"` option) allows newlines inside\n              array brackets, because this is a common pattern\n- `\"always\"` does not require spaces or newlines in empty array literals `[]`\n",
+    "options": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "enum": [
+                "always",
+                "never"
+              ]
+            }
+          ],
+          "minItems": 0,
+          "maxItems": 1
+        },
+        {
+          "type": "object",
+          "properties": {
+            "singleValue": {
+              "type": "boolean"
+            },
+            "objectsInArrays": {
+              "type": "boolean"
+            },
+            "arraysInArrays": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "optionExamples": [
+      "\n\"array-bracket-spacing\": [true, \"always\"]\n",
+      "\n\"array-bracket-spacing\": [true, \"never\"]\n",
+      "\n\"array-bracket-spacing\": [true, \"never\", {\n  \"arraysInArrays\": true\n}]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "array-type": {
+    "description": "Requires using either 'T[]' or 'Array<T>' for arrays.",
+    "hasFix": true,
+    "optionsDescription": "\nOne of the following arguments must be provided:\n\n* `\"array\"` enforces use of `T[]` for all types T.\n* `\"generic\"` enforces use of `Array<T>` for all types T.\n* `\"array-simple\"` enforces use of `T[]` if `T` is a simple type (primitive or type reference).",
+    "options": {
+      "type": "string",
+      "enum": [
+        "array",
+        "generic",
+        "array-simple"
+      ]
+    },
+    "optionExamples": [
+      [
+        true,
+        "array"
+      ],
+      [
+        true,
+        "generic"
+      ],
+      [
+        true,
+        "array-simple"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "arrow-parens": {
+    "description": "Requires parentheses around the parameters of arrow function definitions.",
+    "hasFix": true,
+    "rationale": "Maintains stylistic consistency with other arrow function definitions.",
+    "optionsDescription": "\nIf `ban-single-arg-parens` is specified, then arrow functions with one parameter\nmust not have parentheses if removing them is allowed by TypeScript.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "ban-single-arg-parens"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ban-single-arg-parens"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "arrow-return-shorthand": {
+    "description": "Suggests to convert `() => { return x; }` to `() => x`.",
+    "hasFix": true,
+    "optionsDescription": "\nIf `multiline` is specified, then this will warn even if the function spans multiple lines.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "multiline"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "multiline"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "await-promise": {
+    "description": "Warns for an awaited value that is not a Promise.",
+    "optionsDescription": "\nA list of 'string' names of any additional classes that should also be handled as Promises.\n        ",
+    "options": {
+      "type": "list",
+      "listType": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "Thenable"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "ban": {
+    "description": "Bans the use of specific functions or global methods.",
+    "optionsDescription": "\nA list of banned functions or methods in the following format:\n\n* banning functions:\n  * just the name of the function: `\"functionName\"`\n  * the name of the function in an array with one element: `[\"functionName\"]`\n  * an object in the following format: `{\"name\": \"functionName\", \"message\": \"optional explanation message\"}`\n* banning methods:\n  * an array with the object name, method name and optional message: `[\"functionName\", \"methodName\", \"optional message\"]`\n  * an object in the following format: `{\"name\": [\"objectName\", \"methodName\"], \"message\": \"optional message\"}`\n    * you can also ban deeply nested methods: `{\"name\": [\"foo\", \"bar\", \"baz\"]}` bans `foo.bar.baz()`\n    * the first element can contain a wildcard (`*`) that matches everything. `{\"name\": [\"*\", \"forEach\"]}` bans                  `[].forEach(...)`, `$(...).forEach(...)`, `arr.forEach(...)`, etc.\n",
+    "options": {
+      "type": "list",
+      "listType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minLength": 1,
+            "maxLength": 3
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minLength": 1
+                  }
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        ]
+      }
+    },
+    "optionExamples": [
+      [
+        true,
+        "eval",
+        {
+          "name": "$",
+          "message": "please don't"
+        },
+        [
+          "describe",
+          "only"
+        ],
+        {
+          "name": [
+            "it",
+            "only"
+          ],
+          "message": "don't focus tests"
+        },
+        {
+          "name": [
+            "chai",
+            "assert",
+            "equal"
+          ],
+          "message": "Use 'strictEqual' instead."
+        },
+        {
+          "name": [
+            "*",
+            "forEach"
+          ],
+          "message": "Use a regular for loop instead."
+        }
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "ban-comma-operator": {
+    "description": "Bans the comma operator.",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "ban-types": {
+    "description": "\nBans specific types from being used. Does not ban the\ncorresponding runtime objects from being used.",
+    "options": {
+      "type": "list",
+      "listType": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minLength": 1,
+        "maxLength": 2
+      }
+    },
+    "optionsDescription": "\nA list of `[\"regex\", \"optional explanation here\"]`, which bans\ntypes that match `regex`",
+    "optionExamples": [
+      [
+        true,
+        [
+          "Object",
+          "Use {} instead."
+        ],
+        [
+          "String"
+        ]
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "binary-expression-operand-order": {
+    "description": "\nIn a binary expression, a literal should always be on the right-hand side if possible.\nFor example, prefer 'x + 1' over '1 + x'.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "block-spacing": {
+    "source": "tslint-eslint-rules"
+  },
+  "brace-style": {
+    "source": "tslint-eslint-rules"
+  },
+  "callable-types": {
+    "description": "An interface or literal type with just a call signature can be written as a function type.",
+    "rationale": "style",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "type": "style",
+    "typescriptOnly": true,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "chai-prefer-contains-to-index-of": {
+    "type": "maintainability",
+    "description": "Avoid Chai assertions that invoke indexOf and compare for a -1 result.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "chai-vague-errors": {
+    "type": "maintainability",
+    "description": "Avoid Chai assertions that result in vague errors",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "class-name": {
+    "description": "Enforces PascalCased class and interface names.",
+    "rationale": "Makes it easy to differentiate classes from regular variables at a glance.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "comment-format": {
+    "description": "Enforces formatting rules for single-line comments.",
+    "rationale": "Helps maintain a consistent, readable style in your codebase.",
+    "optionsDescription": "\nThree arguments may be optionally provided:\n\n* `\"check-space\"` requires that all single-line comments must begin with a space, as in `// comment`\n    * note that for comments starting with multiple slashes, e.g. `///`, leading slashes are ignored\n    * TypeScript reference comments are ignored completely\n* `\"check-lowercase\"` requires that the first non-whitespace character of a comment must be lowercase, if applicable.\n* `\"check-uppercase\"` requires that the first non-whitespace character of a comment must be uppercase, if applicable.\n\nExceptions to `\"check-lowercase\"` or `\"check-uppercase\"` can be managed with object that may be passed as last argument.\n\nOne of two options can be provided in this object:\n\n    * `\"ignore-words\"`  - array of strings - words that will be ignored at the beginning of the comment.\n    * `\"ignore-pattern\"` - string - RegExp pattern that will be ignored at the beginning of the comment.\n",
+    "options": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "check-space",
+              "check-lowercase",
+              "check-uppercase"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ignore-words": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ignore-pattern": {
+                "type": "string"
+              }
+            },
+            "minProperties": 1,
+            "maxProperties": 1
+          }
+        ]
+      },
+      "minLength": 1,
+      "maxLength": 4
+    },
+    "optionExamples": [
+      [
+        true,
+        "check-space",
+        "check-uppercase"
+      ],
+      [
+        true,
+        "check-lowercase",
+        {
+          "ignore-words": [
+            "TODO",
+            "HACK"
+          ]
+        }
+      ],
+      [
+        true,
+        "check-lowercase",
+        {
+          "ignore-pattern": "STD\\w{2,3}\\b"
+        }
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "completed-docs": {
+    "description": "Enforces documentation for important items be filled out.",
+    "optionsDescription": "\n`true` to enable for [classes, functions, methods, properties]],\nor an array with each item in one of two formats:\n\n* `string` to enable for that type\n* `object` keying types to when their documentation is required:\n    * `\"methods\"` and `\"properties\"` may specify:\n        * `\"privacies\"`:\n            * `\"all\"`\n            * `\"private\"`\n            * `\"protected\"`\n            * `\"public\"`\n        * `\"locations\"`:\n            * `\"all\"`\n            * `\"instance\"`\n            * `\"static\"`\n    * Other types may specify `\"visibilities\"`:\n        * `\"all\"`\n        * `\"exported\"`\n        * `\"internal\"`\n    * All types may also provide `\"tags\"`\n      with members specifying tags that allow the docs to not have a body.\n        * `\"content\"`: Object mapping tags to `RegExp` bodies content allowed to count as complete docs.\n        * `\"exists\"`: Array of tags that must only exist to count as complete docs.\n\nTypes that may be enabled are:\n\n* `\"classes\"`\n* `\"enums\"`\n* `\"enum-members\"`\n* `\"functions\"`\n* `\"interfaces\"`\n* `\"methods\"`\n* `\"namespaces\"`\n* `\"properties\"`\n* `\"types\"`\n* `\"variables\"`",
+    "options": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "options": [
+              "classes",
+              "enums",
+              "functions",
+              "interfaces",
+              "methods",
+              "namespaces",
+              "properties",
+              "types",
+              "variables"
+            ],
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "classes": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "enums": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "enum-members": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "functions": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "interfaces": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "methods": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "locations": {
+                    "enum": [
+                      "all",
+                      "instance",
+                      "static"
+                    ],
+                    "type": "string"
+                  },
+                  "privacies": {
+                    "enum": [
+                      "all",
+                      "private",
+                      "protected",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "namespaces": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "properties": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "locations": {
+                    "enum": [
+                      "all",
+                      "instance",
+                      "static"
+                    ],
+                    "type": "string"
+                  },
+                  "privacies": {
+                    "enum": [
+                      "all",
+                      "private",
+                      "protected",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "types": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "variables": {
+                "properties": {
+                  "tags": {
+                    "properties": {
+                      "content": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "exists": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    }
+                  },
+                  "visibilities": {
+                    "enum": [
+                      "all",
+                      "exported",
+                      "internal"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "enums",
+        "functions",
+        "methods"
+      ],
+      [
+        true,
+        {
+          "enums": true,
+          "functions": {
+            "visibilities": [
+              "exported"
+            ]
+          },
+          "methods": {
+            "locations": "instance",
+            "privacies": [
+              "public",
+              "protected"
+            ]
+          },
+          "tags": {
+            "content": {
+              "see": [
+                "#.*"
+              ]
+            },
+            "exists": [
+              "inheritdoc"
+            ]
+          }
+        }
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "curly": {
+    "description": "Enforces braces for `if`/`for`/`do`/`while` statements.",
+    "rationale": "\n```ts\nif (foo === bar)\n    foo++;\n    bar++;\n```\n\nIn the code above, the author almost certainly meant for both `foo++` and `bar++`\nto be executed only if `foo === bar`. However, he forgot braces and `bar++` will be executed\nno matter what. This rule could prevent such a mistake.",
+    "optionsDescription": "\nOne of the following options may be provided:\n\n* `\"as-needed\"` forbids any unnecessary curly braces.\n* `\"ignore-same-line\"` skips checking braces for control-flow statements\nthat are on one line and start on the same line as their control-flow keyword\n        ",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "as-needed",
+          "ignore-same-line"
+        ]
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-same-line"
+      ],
+      [
+        true,
+        "as-needed"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "cyclomatic-complexity": {
+    "description": "Enforces a threshold of cyclomatic complexity.",
+    "descriptionDetails": "\nCyclomatic complexity is assessed for each function of any type. A starting value of 0\nis assigned and this value is then incremented for every statement which can branch the\ncontrol flow within the function. The following statements and expressions contribute\nto cyclomatic complexity:\n* `catch`\n* `if` and `? :`\n* `||` and `&&` due to short-circuit evaluation\n* `for`, `for in` and `for of` loops\n* `while` and `do while` loops\n* `case` clauses that contain statements",
+    "rationale": "\nCyclomatic complexity is a code metric which indicates the level of complexity in a\nfunction. High cyclomatic complexity indicates confusing code which may be prone to\nerrors or difficult to modify.",
+    "optionsDescription": "\nAn optional upper limit for cyclomatic complexity can be specified. If no limit option\nis provided a default value of 20 will be used.",
+    "options": {
+      "type": "number",
+      "minimum": 2
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        20
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "deprecation": {
+    "description": "Warns when deprecated APIs are used.",
+    "descriptionDetails": "Any usage of an identifier\n            with the @deprecated JSDoc annotation will trigger a warning.\n            See http://usejsdoc.org/tags-deprecated.html",
+    "rationale": "Deprecated APIs should be avoided, and usage updated.",
+    "optionsDescription": "",
+    "options": null,
+    "optionExamples": [],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "encoding": {
+    "description": "Enforces UTF-8 file encoding.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "eofline": {
+    "description": "Ensures the file ends with a newline.",
+    "descriptionDetails": "Fix for single-line files is not supported.",
+    "rationale": "It is a [standard convention](http://stackoverflow.com/q/729692/3124288) to end files with a newline.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "hasFix": true,
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "export-name": {
+    "type": "maintainability",
+    "description": "The name of the exported module must match the filename of the source file",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "file-header": {
+    "description": "Enforces a certain header comment for all files, matched by a regular expression.",
+    "optionsDescription": "Regular expression to match the header.",
+    "options": {
+      "type": "string"
+    },
+    "optionExamples": [
+      [
+        true,
+        "Copyright \\d{4}"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "forin": {
+    "description": "Requires a `for ... in` statement to be filtered with an `if` statement.",
+    "rationale": "\n```ts\nfor (let key in someObject) {\n    if (someObject.hasOwnProperty(key)) {\n        // code here\n    }\n}\n```\nPrevents accidental iteration over properties inherited from an object's prototype.\nSee [MDN's `for...in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in)\ndocumentation for more information about `for...in` loops.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "function-name": {
+    "type": "maintainability",
+    "description": "Applies a naming convention to function names and method names",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "handle-callback-err": {
+    "description": "enforce error handling in callbacks",
+    "rationale": "\nIn Node.js, a common pattern for dealing with asynchronous behavior is called the callback\npattern. This pattern expects an Error object or null as the first argument of the callback.\nForgetting to handle these errors can lead to some really strange behavior in your\napplication.\n",
+    "optionsDescription": "\nThe rule takes a string option: the name of the error parameter. The default is\n`\"err\"`.\n\nSometimes the name of the error variable is not consistent across the project, so you need a\nmore flexible configuration to ensure that the rule reports all unhandled errors.\n\nIf the configured name of the error variable begins with a `^` it is considered to be a\nregexp pattern.\n\n- If the option is `\"^(err|error|anySpecificError)$\"`, the rule reports unhandled errors\n  where the parameter name can be `err`, `error` or `anySpecificError`.\n- If the option is `\"^.+Error$\"`, the rule reports unhandled errors where the parameter\n  name ends with `Error` (for example, `connectionError` or `validationError` will\n  match).\n- If the option is `\"^.*(e|E)rr\"`, the rule reports unhandled errors where the parameter\n  name matches any string that contains `err` or `Err` (for example, `err`, `error`,\n  `anyError`, `some_err` will match).\n\nIn addition to the string we may specify an options object with the following property:\n\n- `allowProperties`: (`true` by default) When this is set to `false` the rule will not\n  report unhandled errors as long as the error object is handled without accessing any of its\n  properties at least once. For instance, `(err) => console.log(err.stack)` would report an\n  issue when `allowProperties` is set to `false` because `err` is not handled on its\n  own.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allowProperties": "boolean"
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minLength": 0,
+      "maxLength": 2
+    },
+    "optionExamples": [
+      "\n\"handle-callback-err\": [true, \"error\"]\n",
+      "\n\"handle-callback-err\": [true, \"^(err|error|anySpecificError)$\"]\n",
+      "\n\"handle-callback-err\": [true, { \"allowProperties\": false }]\n",
+      "\n\"handle-callback-err\": [true, \"^(err|error|anySpecificError)$\", { \"allowProperties\": false }]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "maintainability",
+    "source": "tslint-eslint-rules"
+  },
+  "import-blacklist": {
+    "description": "\nDisallows importing the specified modules directly via `import` and `require`.\nInstead only sub modules may be imported from that module.",
+    "rationale": "\nSome libraries allow importing their submodules instead of the entire module.\nThis is good practise as it avoids loading unused modules.",
+    "optionsDescription": "A list of blacklisted modules.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "rxjs",
+        "lodash"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "import-name": {
+    "type": "maintainability",
+    "description": "The name of the imported module must match the name of the thing being imported",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "import-spacing": {
+    "description": "Ensures proper spacing between import statement keywords",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "indent": {
+    "description": "Enforces indentation with tabs or spaces.",
+    "rationale": "\nUsing only one of tabs or spaces for indentation leads to more consistent editor behavior,\ncleaner diffs in version control, and easier programmatic manipulation.",
+    "optionsDescription": "\nOne of the following arguments must be provided:\n\n* `spaces` enforces consistent spaces.\n* `tabs` enforces consistent tabs.\n\nA second optional argument specifies indentation size:\n\n* `2` enforces 2 space indentation.\n* `4` enforces 4 space indentation.\n\nIndentation size is required for auto-fixing, but not for rule checking.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string",
+          "enum": [
+            "tabs",
+            "spaces"
+          ]
+        },
+        {
+          "type": "number",
+          "enum": [
+            2,
+            4
+          ]
+        }
+      ],
+      "minLength": 0,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      [
+        true,
+        "spaces"
+      ],
+      [
+        true,
+        "spaces",
+        4
+      ],
+      [
+        true,
+        "tabs",
+        2
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "insecure-random": {
+    "type": "functionality",
+    "description": "Do not use insecure sources for random bytes",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Security",
+    "commonWeaknessEnumeration": "330",
+    "source": "tslint-microsoft-contrib"
+  },
+  "interface-name": {
+    "description": "Requires interface names to begin with a capital 'I'",
+    "rationale": "Makes it easy to differentiate interfaces from regular classes at a glance.",
+    "optionsDescription": "\nOne of the following two options must be provided:\n\n* `\"always-prefix\"` requires interface names to start with an \"I\"\n* `\"never-prefix\"` requires interface names to not have an \"I\" prefix",
+    "options": {
+      "type": "string",
+      "enum": [
+        "always-prefix",
+        "never-prefix"
+      ]
+    },
+    "optionExamples": [
+      [
+        true,
+        "always-prefix"
+      ],
+      [
+        true,
+        "never-prefix"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "interface-over-type-literal": {
+    "description": "Prefer an interface declaration over a type literal (`type T = { ... }`)",
+    "rationale": "Interfaces are generally preferred over type literals because interfaces can be implemented, extended and merged.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "jquery-deferred-must-complete": {
+    "type": "maintainability",
+    "description": "When a JQuery Deferred instance is created, then either reject() or resolve() must be called on it within all code branches in the scope.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "jsdoc-format": {
+    "description": "Enforces basic format rules for JSDoc comments.",
+    "descriptionDetails": "\nThe following rules are enforced for JSDoc comments (comments starting with `/**`):\n\n* each line contains an asterisk and asterisks must be aligned\n* each asterisk must be followed by either a space or a newline (except for the first and the last)\n* the only characters before the asterisk on each line must be whitespace characters\n* one line comments must start with `/** ` and end with `*/`\n* multiline comments don't allow text after `/** ` in the first line (with option `\"check-multiline-start\"`)\n        ",
+    "rationale": "Helps maintain a consistent, readable style for JSDoc comments.",
+    "optionsDescription": "\nYou can optionally specify the option `\"check-multiline-start\"` to enforce the first line of a\nmultiline JSDoc comment to be empty.\n        ",
+    "options": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "check-multiline-start"
+        ]
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "check-multiline-start"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "jsx-alignment": {
+    "description": "Enforces consistent and readable vertical alignment of JSX tags and attributes",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-ban-props": {
+    "description": "Bans the use of specific props.",
+    "optionsDescription": "\nA list of `['propName', 'optional explanation here']` which bans the prop called 'propName'.",
+    "options": {
+      "type": "list",
+      "listType": {
+        "type": "string",
+        "items": {
+          "type": "string"
+        },
+        "minLength": 1,
+        "maxLength": 2
+      }
+    },
+    "optionExamples": [
+      "[true, [\"someProp], [\"anotherProp\", \"Optional explanation\"]]"
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-boolean-value": {
+    "description": "Enforce boolean attribute notation in jsx.",
+    "optionsDescription": "\nOne of the following two options must be provided:\n* `\"always\"` requires JSX boolean values to always be set.\n* `\"never\"` prevents JSX boolean values to be explicity set as `true`",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        }
+      ],
+      "minLength": 1,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "[true, \"always\"]",
+      "[true, \"never\"]"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-curly-spacing": {
+    "description": "Checks JSX curly braces spacing",
+    "optionsDescription": "\nOne of the following two options must be provided:\n\n* `\"always\"` requires JSX attributes to have spaces between curly braces\n* `\"never\"` requires JSX attributes to NOT have spaces between curly braces",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        }
+      ],
+      "minLength": 1,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "[true, \"always\"]",
+      "[true, \"never\"]"
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint-react"
+  },
+  "jsx-equals-spacing": {
+    "description": "\nDisallow or enforce spaces around equal signs in JSX attributes",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        }
+      ],
+      "minLength": 1,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "[true, \"always\"]",
+      "[true, \"never\"]"
+    ],
+    "optionsDescription": "\nOne of the following two options must be provided:\n\n* `\"always\"` requires JSX attributes to have spaces before and after the equals sign\n* `\"never\"` requires JSX attributes to NOT have spaces before and after the equals sign",
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-key": {
+    "description": "Warn if an element that likely requires a key prop — namely,             one present in an array literal or an arrow function expression.",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-no-bind": {
+    "description": "Forbids function binding in JSX attributes. This has the same intent             as jsx-no-lambda in helping you avoid excessive re-renders.",
+    "descriptionDetails": "Note that this currently only does a simple syntactic check,             not a semantic one (it doesn't use the type checker). So it may             have some rare false positives if you define your own .bind function             and supply this as a parameter.",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-no-lambda": {
+    "description": "Checks for fresh lambda literals used in JSX attributes",
+    "descriptionDetails": "Creating new anonymous functions (with either the function syntax or             ES2015 arrow syntax) inside the render call stack works against pure component             rendering. When doing an equality check between two lambdas, React will always             consider them unequal values and force the component to re-render more often than necessary.",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-no-multiline-js": {
+    "description": "Checks for multiline JS expressions inside JSX expressions",
+    "descriptionDetails": "This helps reduce mental overhead when parsing JSX syntax",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-no-string-ref": {
+    "description": "Checks for string literal refs",
+    "descriptionDetails": "This syntax is deprecated and will be removed in a future version of React",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-self-close": {
+    "description": "Checks that JSX elements with no children are self-closing",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "jsx-use-translation-function": {
+    "source": "tslint-react"
+  },
+  "jsx-wrap-multiline": {
+    "description": "Checks that multiline JSX elements are wrapped in parens",
+    "options": null,
+    "optionsDescription": "",
+    "optionExamples": [
+      "true"
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint-react"
+  },
+  "label-position": {
+    "description": "Only allows labels in sensible locations.",
+    "descriptionDetails": "This rule only allows labels to be on `do/for/while/switch` statements.",
+    "rationale": "\nLabels in JavaScript only can be used in conjunction with `break` or `continue`,\nconstructs meant to be used for loop flow control. While you can theoretically use\nlabels on any block statement in JS, it is considered poor code structure to do so.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "linebreak-style": {
+    "description": "Enforces a consistent linebreak style.",
+    "optionsDescription": "\nOne of the following options must be provided:\n\n* `\"LF\"` requires LF (`\\n`) linebreaks\n* `\"CRLF\"` requires CRLF (`\\r\\n`) linebreaks",
+    "options": {
+      "type": "string",
+      "enum": [
+        "LF",
+        "CRLF"
+      ]
+    },
+    "optionExamples": [
+      [
+        true,
+        "LF"
+      ],
+      [
+        true,
+        "CRLF"
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "match-default-export-name": {
+    "description": "\nRequires that a default import have the same name as the declaration it imports.\nDoes nothing for anonymous default exports.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "max-classes-per-file": {
+    "description": "\nA file may not contain more than the specified number of classes",
+    "rationale": "\nEnsures that files have a single responsibility so that that classes each exist in their own files",
+    "optionsDescription": "\nThe one required argument is an integer indicating the maximum number of classes that can appear in a\nfile. An optional argument `\"exclude-class-expressions\"` can be provided to exclude class expressions\nfrom the overall class count.",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "number",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "enum": [
+            "exclude-class-expressions"
+          ]
+        }
+      ],
+      "additionalItems": false,
+      "minLength": 1,
+      "maxLength": 2
+    },
+    "optionExamples": [
+      [
+        true,
+        1
+      ],
+      [
+        true,
+        5,
+        "exclude-class-expressions"
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "max-file-line-count": {
+    "description": "Requires files to remain under a certain number of lines",
+    "rationale": "\nLimiting the number of lines allowed in a file allows files to remain small,\nsingle purpose, and maintainable.",
+    "optionsDescription": "An integer indicating the maximum number of lines.",
+    "options": {
+      "type": "number",
+      "minimum": "1"
+    },
+    "optionExamples": [
+      [
+        true,
+        300
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "max-func-body-length": {
+    "type": "maintainability",
+    "description": "Avoid long functions.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "recommendation": "[true, 100, {\"ignore-parameters-to-function-regex\": \"describe\"}],",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "max-line-length": {
+    "description": "Requires lines to be under a certain max length.",
+    "rationale": "\nLimiting the length of a line of code improves code readability.\nIt also makes comparing code side-by-side easier and improves compatibility with\nvarious editors, IDEs, and diff viewers.",
+    "optionsDescription": "An integer indicating the max length of lines.",
+    "options": {
+      "type": "number",
+      "minimum": "1"
+    },
+    "optionExamples": [
+      [
+        true,
+        120
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "member-access": {
+    "description": "Requires explicit visibility declarations for class members.",
+    "rationale": "Explicit visibility declarations can make code more readable and accessible for those new to TS.",
+    "optionsDescription": "\nThese arguments may be optionally provided:\n\n* `\"no-public\"` forbids public accessibility to be specified, because this is the default.\n* `\"check-accessor\"` enforces explicit visibility on get/set accessors\n* `\"check-constructor\"`  enforces explicit visibility on constructors\n* `\"check-parameter-property\"`  enforces explicit visibility on parameter properties",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "no-public",
+          "check-accessor",
+          "check-constructor",
+          "check-parameter-property"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 4
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "no-public"
+      ],
+      [
+        true,
+        "check-accessor"
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "member-ordering": {
+    "description": "Enforces member ordering.",
+    "rationale": "A consistent ordering for class members can make classes easier to read, navigate, and edit.",
+    "optionsDescription": "\nOne argument, which is an object, must be provided. It should contain an `order` property.\nThe `order` property should have a value of one of the following strings:\n\n* `fields-first`\n* `instance-sandwich`\n* `statics-first`\n\nAlternatively, the value for `order` maybe be an array consisting of the following strings:\n\n* `public-static-field`\n* `public-static-method`\n* `protected-static-field`\n* `protected-static-method`\n* `private-static-field`\n* `private-static-method`\n* `public-instance-field`\n* `protected-instance-field`\n* `private-instance-field`\n* `public-constructor`\n* `protected-constructor`\n* `private-constructor`\n* `public-instance-method`\n* `protected-instance-method`\n* `private-instance-method`\n\nYou can also omit the access modifier to refer to \"public-\", \"protected-\", and \"private-\" all at once; for example, \"static-field\".\n\nYou can also make your own categories by using an object instead of a string:\n\n    {\n        \"name\": \"static non-private\",\n        \"kinds\": [\n            \"public-static-field\",\n            \"protected-static-field\",\n            \"public-static-method\",\n            \"protected-static-method\"\n        ]\n    }\n\nThe 'alphabetize' option will enforce that members within the same category should be alphabetically sorted by name.",
+    "options": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "fields-first",
+                "instance-sandwich",
+                "statics-first"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "public-static-field",
+                  "public-static-method",
+                  "protected-static-field",
+                  "protected-static-method",
+                  "private-static-field",
+                  "private-static-method",
+                  "public-instance-field",
+                  "protected-instance-field",
+                  "private-instance-field",
+                  "public-constructor",
+                  "protected-constructor",
+                  "private-constructor",
+                  "public-instance-method",
+                  "protected-instance-method",
+                  "private-instance-method"
+                ]
+              },
+              "maxLength": 13
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionExamples": [
+      [
+        true,
+        {
+          "order": "fields-first"
+        }
+      ],
+      [
+        true,
+        {
+          "order": [
+            "public-static-field",
+            "public-instance-field",
+            "public-constructor",
+            "private-static-field",
+            "private-instance-field",
+            "private-constructor",
+            "public-instance-method",
+            "protected-instance-method",
+            "private-instance-method"
+          ]
+        }
+      ],
+      [
+        true,
+        {
+          "order": [
+            {
+              "name": "static non-private",
+              "kinds": [
+                "public-static-field",
+                "protected-static-field",
+                "public-static-method",
+                "protected-static-method"
+              ]
+            },
+            "constructor"
+          ]
+        }
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "missing-jsdoc": {
+    "type": "maintainability",
+    "description": "All files must have a top level JSDoc comment.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "missing-optional-annotation": {
+    "type": "maintainability",
+    "description": "Deprecated - This rule is now enforced by the TypeScript compiler",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Deprecated",
+    "recommendation": "false,  // now supported by TypeScript compiler",
+    "source": "tslint-microsoft-contrib"
+  },
+  "mocha-avoid-only": {
+    "type": "maintainability",
+    "description": "Do not invoke Mocha's describe.only, it.only or context.only functions.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "mocha-no-side-effect-code": {
+    "type": "maintainability",
+    "description": "All test logic in a Mocha test case should be within Mocha lifecycle method.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "mocha-unneeded-done": {
+    "type": "maintainability",
+    "description": "A function declares a MochaDone parameter but only resolves it synchronously in the main function.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "source": "tslint-microsoft-contrib"
+  },
+  "new-parens": {
+    "description": "Requires parentheses when invoking a constructor via the `new` keyword.",
+    "rationale": "Maintains stylistic consistency with other function calls.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "newline-before-return": {
+    "description": "Enforces blank line before return when not the only line in the block.",
+    "rationale": "Helps maintain a readable style in your codebase.",
+    "optionsDescription": "Not configurable.",
+    "options": {},
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-absolute-import-to-own-parent": {
+    "source": "bm-tslint-rules"
+  },
+  "no-angle-bracket-type-assertion": {
+    "description": "Requires the use of `as Type` for type assertions instead of `<Type>`.",
+    "hasFix": true,
+    "rationale": "\nBoth formats of type assertions have the same effect, but only `as` type assertions\nwork in `.tsx` files. This rule ensures that you have a consistent type assertion style\nacross your codebase.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-any": {
+    "description": "Disallows usages of `any` as a type declaration.",
+    "hasFix": false,
+    "rationale": "Using `any` as a type declaration nullifies the compile-time benefits of the type system.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-arg": {
+    "description": "Disallows use of `arguments.callee`.",
+    "rationale": "\nUsing `arguments.callee` makes various performance optimizations impossible.\nSee [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee)\nfor more details on why to avoid `arguments.callee`.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-backbone-get-set-outside-model": {
+    "type": "maintainability",
+    "description": "Avoid using `model.get('x')` and `model.set('x', value)` Backbone accessors outside of the owning model.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-banned-terms": {
+    "type": "maintainability",
+    "description": "Do not use banned terms: caller, callee, eval, arguments.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "676, 242, 116",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-bitwise": {
+    "description": "Disallows bitwise operators.",
+    "descriptionDetails": "\nSpecifically, the following bitwise operators are banned:\n`&`, `&=`, `|`, `|=`,\n`^`, `^=`, `<<`, `<<=`,\n`>>`, `>>=`, `>>>`, `>>>=`, and `~`.\nThis rule does not ban the use of `&` and `|` for intersection and union types.",
+    "rationale": "\nBitwise operators are often typos - for example `bool1 & bool2` instead of `bool1 && bool2`.\nThey also can be an indicator of overly clever code which decreases maintainability.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-boolean-literal-compare": {
+    "description": "Warns on comparison to a boolean literal, as in `x === true`.",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-conditional-assignment": {
+    "description": "Disallows any type of assignment in conditionals.",
+    "descriptionDetails": "This applies to `do-while`, `for`, `if`, and `while` statements and conditional (ternary) expressions.",
+    "rationale": "\nAssignments in conditionals are often typos:\nfor example `if (var1 = var2)` instead of `if (var1 == var2)`.\nThey also can be an indicator of overly clever code which decreases maintainability.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-consecutive-blank-lines": {
+    "description": "Disallows one or more blank lines in a row.",
+    "hasFix": true,
+    "rationale": "Helps maintain a readable style in your codebase.",
+    "optionsDescription": "\nAn optional number of maximum allowed sequential blanks can be specified. If no value\nis provided, a default of 1 will be used.",
+    "options": {
+      "type": "number",
+      "minimum": "1"
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        2
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-console": {
+    "description": "Bans the use of specified `console` methods.",
+    "rationale": "In general, `console` methods aren't appropriate for production code.",
+    "optionsDescription": "A list of method names to ban. If no method names are provided, all console methods are banned.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "optionExamples": [
+      [
+        true,
+        "log",
+        "error"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-constant-condition": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-constant-condition"
+    ]
+  },
+  "no-construct": {
+    "description": "Disallows access to the constructors of `String`, `Number`, and `Boolean`.",
+    "descriptionDetails": "Disallows constructor use such as `new Number(foo)` but does not disallow `Number(foo)`.",
+    "rationale": "\nThere is little reason to use `String`, `Number`, or `Boolean` as constructors.\nIn almost all cases, the regular function-call version is more appropriate.\n[More details](http://stackoverflow.com/q/4719320/3124288) are available on StackOverflow.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-control-regex": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-control-regex"
+    ]
+  },
+  "no-cookies": {
+    "type": "maintainability",
+    "description": "Do not use cookies",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "315, 539, 565, 614",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-debugger": {
+    "description": "Disallows `debugger` statements.",
+    "rationale": "In general, `debugger` statements aren't appropriate for production code.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-default-export": {
+    "description": "Disallows default exports in ES6-style modules.",
+    "descriptionDetails": "Use named exports instead.",
+    "rationale": "\nNamed imports/exports [promote clarity](https://github.com/palantir/tslint/issues/1182#issue-151780453).\nIn addition, current tooling differs on the correct way to handle default imports/exports.\nAvoiding them all together can help avoid tooling bugs and conflicts.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-delete-expression": {
+    "type": "maintainability",
+    "description": "Do not delete expressions. Only properties should be deleted",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-disable-auto-sanitization": {
+    "type": "maintainability",
+    "description": "Do not disable auto-sanitization of HTML because this opens up your page to an XSS attack. ",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "157, 159, 75, 79, 85, 749, 676",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-document-domain": {
+    "type": "maintainability",
+    "description": "Do not write to document.domain. Scripts setting document.domain to any value should be validated to ensure that the value is on a list of allowed sites.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-document-write": {
+    "type": "maintainability",
+    "description": "Do not use document.write",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "79, 85",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-duplicate-case": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-duplicate-case"
+    ]
+  },
+  "no-duplicate-imports": {
+    "description": "\nDisallows multiple import statements from the same module.",
+    "rationale": "\nUsing a single import statement per module will make the code clearer because you can see everything being imported\nfrom that module on one line.",
+    "optionsDescription": "Not configurable",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-duplicate-parameter-names": {
+    "type": "maintainability",
+    "description": "Deprecated - This rule is now enforced by the TypeScript compiler",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Deprecated",
+    "recommendation": "false, // now supported by TypeScript compiler",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-duplicate-super": {
+    "description": "Warns if 'super()' appears twice in a constructor.",
+    "rationale": "The second call to 'super()' will fail at runtime.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-duplicate-switch-case": {
+    "description": "Prevents duplicate cases in switch statements.",
+    "optionExamples": [
+      true
+    ],
+    "options": null,
+    "optionsDescription": "",
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-duplicate-variable": {
+    "description": "Disallows duplicate variable declarations in the same block scope.",
+    "descriptionDetails": "\nThis rule is only useful when using the `var` keyword -\nthe compiler will detect redeclarations of `let` and `const` variables.",
+    "rationale": "\nA variable can be reassigned if necessary -\nthere's no good reason to have a duplicate variable declaration.",
+    "optionsDescription": "You can specify `\"check-parameters\"` to check for variables with the same name as a paramter.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "check-parameters"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "check-parameters"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-empty": {
+    "description": "Disallows empty blocks.",
+    "descriptionDetails": "Blocks with a comment inside are not considered empty.",
+    "rationale": "Empty blocks are often indicators of missing code.",
+    "optionsDescription": "\nIf `allow-empty-catch` is specified, then catch blocks are allowed to be empty.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "allow-empty-catch"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-empty-catch"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-empty-character-class": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-empty-interface": {
+    "description": "Forbids empty interfaces.",
+    "rationale": "An empty interface is equivalent to its supertype (or `{}`).",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-empty-interfaces": {
+    "type": "maintainability",
+    "description": "Do not use empty interfaces.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Deprecated",
+    "recommendation": "false, // use tslint no-empty-interface rule instead",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-empty-line-after-opening-brace": {
+    "type": "maintainability",
+    "description": "Avoid an empty line after an opening brace",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Whitespace",
+    "recommendation": "false,",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-eval": {
+    "description": "Disallows `eval` function invocations.",
+    "rationale": "\n`eval()` is dangerous as it allows arbitrary code execution with full privileges. There are\n[alternatives](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)\nfor most of the use cases for `eval()`.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-ex-assign": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-exec-script": {
+    "type": "maintainability",
+    "description": "Do not use the execScript functions",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95, 676",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-extra-boolean-cast": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-extra-semi": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-floating-promises": {
+    "description": "Promises returned by functions must be handled appropriately.",
+    "descriptionDetails": "Use `no-unused-expression` in addition to this rule to reveal even more floating promises.",
+    "optionsDescription": "\nA list of 'string' names of any additional classes that should also be handled as Promises.\n        ",
+    "options": {
+      "type": "list",
+      "listType": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "JQueryPromise"
+      ]
+    ],
+    "rationale": "Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.",
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-for-in": {
+    "type": "maintainability",
+    "description": "Avoid use of for-in statements. They can be replaced by Object.keys",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-for-in-array": {
+    "description": "Disallows iterating over an array with a for-in loop.",
+    "descriptionDetails": "\nA for-in loop (`for (var k in o)`) iterates over the properties of an Object.\n\nWhile it is legal to use for-in loops with array types, it is not common.\nfor-in will iterate over the indices of the array as strings, omitting any \"holes\" in\nthe array.\n\nMore common is to use for-of, which iterates over the values of an array.\nIf you want to iterate over the indices, alternatives include:\n\narray.forEach((value, index) => { ... });\nfor (const [index, value] of array.entries()) { ... }\nfor (let i = 0; i < array.length; i++) { ... }\n",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "requiresTypeInfo": true,
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-function-constructor-with-string-args": {
+    "type": "maintainability",
+    "description": "Do not use the version of the Function constructor that accepts a string argument to define the body of the function",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95, 676, 242, 116",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-function-expression": {
+    "type": "maintainability",
+    "description": "Do not use function expressions; use arrow functions (lambdas) instead.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-http-string": {
+    "type": "maintainability",
+    "description": "Do not use strings that start with 'http:'. URL strings should start with 'https:'. ",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "recommendation": "[true, \"http://www.example.com/?.*\", \"http://www.examples.com/?.*\"],",
+    "commonWeaknessEnumeration": "319",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-implicit-dependencies": {
+    "description": "Disallows importing modules that are not listed as dependency in the project's package.json",
+    "descriptionDetails": "\nDisallows importing transient dependencies and modules installed above your package's root directory.\n        ",
+    "optionsDescription": "\nBy default the rule looks at `\"dependencies\"` and `\"peerDependencies\"`.\nBy adding the `\"dev\"` option the rule looks at `\"devDependencies\"` instead of `\"peerDependencies\"`.\nBy adding the `\"optional\"` option the rule also looks at `\"optionalDependencies\"`.\n        ",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "dev",
+          "optional"
+        ]
+      },
+      "minItems": 0,
+      "maxItems": 2
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "dev"
+      ],
+      [
+        true,
+        "optional"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-import-side-effect": {
+    "description": "Avoid import statements with side-effect.",
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "ignore-module": "(\\.html|\\.css)$"
+        }
+      ]
+    ],
+    "options": {
+      "items": {
+        "properties": {
+          "ignore-module": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "maxLength": 1,
+      "minLength": 0,
+      "type": "array"
+    },
+    "optionsDescription": "\nOne argument may be optionally provided:\n\n* `ignore-module` allows to specify a regex and ignore modules which it matches.",
+    "rationale": "Imports with side effects may have behavior which is hard for static verification.",
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-increment-decrement": {
+    "type": "maintainability",
+    "description": "Avoid use of increment and decrement operators particularly as part of complicated expressions",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-inferrable-types": {
+    "description": "Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.",
+    "rationale": "Explicit types where they can be easily inferred by the compiler make code more verbose.",
+    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `ignore-params` allows specifying an inferrable type annotation for function params.\nThis can be useful when combining with the `typedef` rule.\n* `ignore-properties` allows specifying an inferrable type annotation for class properties.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "ignore-params",
+          "ignore-properties"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 2
+    },
+    "hasFix": true,
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-params"
+      ],
+      [
+        true,
+        "ignore-params",
+        "ignore-properties"
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-inferred-empty-object-type": {
+    "description": "Disallow type inference of {} (empty object type) at function and constructor call sites",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-inner-declarations": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-inner-html": {
+    "type": "maintainability",
+    "description": "Do not write values to innerHTML, outerHTML, or set HTML using the JQuery html() function.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "79, 85, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-internal-module": {
+    "description": "Disallows internal `module`",
+    "rationale": "Using `module` leads to a confusion of concepts with external modules. Use the newer `namespace` keyword instead.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "no-invalid-regexp": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-invalid-regexp"
+    ]
+  },
+  "no-invalid-template-strings": {
+    "description": "Warns on use of `${` in non-template strings.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-invalid-this": {
+    "description": "Disallows using the `this` keyword outside of classes.",
+    "rationale": "See [the rule's author's rationale here.](https://github.com/palantir/tslint/pull/1105#issue-147549402)",
+    "optionsDescription": "\nOne argument may be optionally provided:\n\n* `check-function-in-method` disallows using the `this` keyword in functions within class methods.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "check-function-in-method"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "check-function-in-method"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-irregular-whitespace": {
+    "description": "Disallow irregular whitespace outside of strings and comments",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-jquery-raw-elements": {
+    "type": "maintainability",
+    "description": "Do not create HTML elements using JQuery and string concatenation. It is error prone and can hide subtle defects.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-magic-numbers": {
+    "description": "\nDisallows the use constant number values outside of variable assignments.\nWhen no list of allowed values is specified, -1, 0 and 1 are allowed by default.",
+    "rationale": "\nMagic numbers should be avoided as they often lack documentation, forcing\nthem to be stored in variables gives them implicit documentation.",
+    "optionsDescription": "A list of allowed numbers.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        1,
+        2,
+        3
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-mergeable-namespace": {
+    "description": "Disallows mergeable namespaces in the same file.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "maintainability",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-missing-visibility-modifiers": {
+    "type": "maintainability",
+    "description": "Deprecated - This rule is in the TSLint product as `member-access`",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Deprecated",
+    "recommendation": "false, // use tslint member-access rule instead",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-misused-new": {
+    "description": "Warns on apparent attempts to define constructors for interfaces or `new` for classes.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-multi-spaces": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-multiline-string": {
+    "type": "maintainability",
+    "description": "Do not declare multiline strings",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "recommendation": "true, // multiline-strings often introduce unnecessary whitespace into the string literals",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-multiple-var-decl": {
+    "type": "maintainability",
+    "description": "Deprecated - This rule is now part of the base TSLint product as the rule named 'one-variable-per-declaration'",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Deprecated",
+    "recommendation": "false,         // use tslint one-variable-per-declaration rule instead",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-namespace": {
+    "description": "Disallows use of internal `module`s and `namespace`s.",
+    "descriptionDetails": "This rule still allows the use of `declare module ... {}`",
+    "rationale": "\nES6-style external modules are the standard way to modularize code.\nUsing `module {}` and `namespace {}` are outdated ways to organize TypeScript code.",
+    "optionsDescription": "\nOne argument may be optionally provided:\n\n* `allow-declarations` allows `declare namespace ... {}` to describe external APIs.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-declarations"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-declarations"
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-non-null-assertion": {
+    "description": "Disallows non-null assertions using the `!` postfix operator.",
+    "rationale": "Using non-null assertion cancels the benefits of the strict null checking mode.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-null-keyword": {
+    "description": "Disallows use of the `null` keyword literal.",
+    "rationale": "\nInstead of having the dual concepts of `null` and`undefined` in a codebase,\nthis rule ensures that only `undefined` is used.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "no-object-literal-type-assertion": {
+    "description": "\nForbids an object literal to appear in a type assertion expression.\nCasting to `any` is still allowed.",
+    "rationale": "\nAlways prefer `const x: T = { ... };` to `const x = { ... } as T;`.\nThe type assertion in the latter case is either unnecessary or hides an error.\nThe compiler will warn for excess properties with this syntax, but not missing required fields.\nFor example: `const x: { foo: number } = {}` will fail to compile, but\n`const x = {} as { foo: number }` will succeed.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-octal-literal": {
+    "type": "maintainability",
+    "description": "Do not use octal literals or escaped octal sequences",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-parameter-properties": {
+    "description": "Disallows parameter properties in class constructors.",
+    "rationale": "\nParameter properties can be confusing to those new to TS as they are less explicit\nthan other ways of declaring and initializing class members.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-parameter-reassignment": {
+    "description": "Disallows reassigning parameters.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-redundant-jsdoc": {
+    "description": "Forbids JSDoc which duplicates TypeScript functionality.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-reference": {
+    "description": "Disallows `/// <reference path=>` imports (use ES6-style imports instead).",
+    "rationale": "\nUsing `/// <reference path=>` comments to load other files is outdated.\nUse ES6-style imports to reference other files.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-reference-import": {
+    "description": "Don't `<reference types=\"foo\" />` if you import `foo` anyway.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-regex-spaces": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:no-regex-spaces"
+    ]
+  },
+  "no-relative-imports": {
+    "type": "maintainability",
+    "description": "Do not use relative paths when importing external modules or ES6 import declarations",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-require-imports": {
+    "description": "Disallows invocation of `require()`.",
+    "rationale": "Prefer the newer ES6-style imports over `require()`.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-reserved-keywords": {
+    "type": "maintainability",
+    "description": "Do not use reserved keywords as names of local variables, fields, functions, or other identifiers.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "398",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-return-await": {
+    "description": "Disallows unnecessary `return await`.",
+    "rationale": "\nAn async function always wraps the return value in a Promise.\nUsing `return await` just adds extra time before the overreaching promise is resolved without changing the semantics.\n        ",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "no-shadowed-variable": {
+    "description": "Disallows shadowing variable declarations.",
+    "rationale": "Shadowing a variable masks access to it and obscures to what value an identifier actually refers.",
+    "optionsDescription": "\nYou can optionally pass an object to disable checking for certain kinds of declarations.\nPossible keys are `\"class\"`, `\"enum\"`, `\"function\"`, `\"import\"`, `\"interface\"`, `\"namespace\"`, `\"typeAlias\"`\nand `\"typeParameter\"`. Just set the value to `false` for the check you want to disable.\nAll checks default to `true`, i.e. are enabled by default.\nNote that you cannot disable variables and parameters.\n        ",
+    "options": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "type": "boolean"
+        },
+        "enum": {
+          "type": "boolean"
+        },
+        "function": {
+          "type": "boolean"
+        },
+        "import": {
+          "type": "boolean"
+        },
+        "interface": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "boolean"
+        },
+        "typeAlias": {
+          "type": "boolean"
+        },
+        "typeParameter": {
+          "type": "boolean"
+        }
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "class": true,
+          "enum": true,
+          "function": true,
+          "interface": false,
+          "namespace": true,
+          "typeAlias": false,
+          "typeParameter": false
+        }
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-single-line-block-comment": {
+    "type": "maintainability",
+    "description": "Avoid single line block comments; use single line comments instead",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Whitespace",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-sparse-arrays": {
+    "description": "Forbids array literals to contain missing elements.",
+    "rationale": "Missing elements are probably an accidentally duplicated comma.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-stateless-class": {
+    "type": "maintainability",
+    "description": "A stateless class represents a failure in the object oriented design of the system.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-immediate": {
+    "type": "maintainability",
+    "description": "Do not use the version of setImmediate that accepts code as a string argument.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95, 676, 242, 116",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-interval": {
+    "type": "maintainability",
+    "description": "Do not use the version of setInterval that accepts code as a string argument.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95, 676, 242, 116",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-based-set-timeout": {
+    "type": "maintainability",
+    "description": "Do not use the version of setTimeout that accepts code as a string argument.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95, 676, 242, 116",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-string-literal": {
+    "description": "\nForbids unnecessary string literal property access.\nAllows `obj[\"prop-erty\"]` (can't be a regular property access).\nDisallows `obj[\"property\"]` (should be `obj.property`).",
+    "rationale": "\nIf `--noImplicitAny` is turned off,\nproperty access via a string literal will be 'any' if the property does not exist.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "no-string-throw": {
+    "description": "Flags throwing plain strings or concatenations of strings because only Errors produce proper stack traces.",
+    "hasFix": true,
+    "options": null,
+    "optionsDescription": "Not configurable.",
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-submodule-imports": {
+    "description": "\nDisallows importing any submodule.",
+    "rationale": "\nSubmodules of some packages are treated as private APIs and the import\npaths may change without deprecation periods. It's best to stick with\ntop-level package exports.",
+    "optionsDescription": "A list of whitelisted package or submodule names.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "rxjs",
+        "@angular/platform-browser",
+        "@angular/core/testing"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-suspicious-comment": {
+    "type": "maintainability",
+    "description": "Do not use suspicious comments, such as BUG, HACK, FIXME, LATER, LATER2, TODO",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "546",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-switch-case-fall-through": {
+    "description": "Disallows falling through case statements.",
+    "descriptionDetails": "\nFor example, the following is not allowed:\n\n```ts\nswitch(foo) {\n    case 1:\n        someFunc(foo);\n    case 2:\n        someOtherFunc(foo);\n}\n```\n\nHowever, fall through is allowed when case statements are consecutive or\na magic `/* falls through */` comment is present. The following is valid:\n\n```ts\nswitch(foo) {\n    case 1:\n        someFunc(foo);\n        /* falls through */\n    case 2:\n    case 3:\n        someOtherFunc(foo);\n}\n```",
+    "rationale": "Fall though in switch statements is often unintentional and a bug.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-this-assignment": {
+    "description": "Disallows unnecessary references to `this`.",
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "allowed-names": [
+            "^self$"
+          ],
+          "allow-destructuring": true
+        }
+      ]
+    ],
+    "options": {
+      "additionalProperties": false,
+      "properties": {
+        "allow-destructuring": {
+          "type": "boolean"
+        },
+        "allowed-names": {
+          "listType": "string",
+          "type": "list"
+        }
+      },
+      "type": "object"
+    },
+    "optionsDescription": "\nTwo options may be provided on an object:\n\n* `allow-destructuring` allows using destructuring to access members of `this` (e.g. `{ foo, bar } = this;`).\n* `allowed-names` may be specified as a list of regular expressions to match allowed variable names.",
+    "rationale": "Assigning a variable to `this` instead of properly using arrow lambdas may be a symptom of pre-ES6 practices or not manging scope well.",
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-trailing-whitespace": {
+    "description": "Disallows trailing whitespace at the end of a line.",
+    "rationale": "Keeps version control diffs clean as it prevents accidental whitespace from being committed.",
+    "optionsDescription": "\nPossible settings are:\n\n* `\"ignore-template-strings\"`: Allows trailing whitespace in template strings.\n* `\"ignore-comments\"`: Allows trailing whitespace in comments.\n* `\"ignore-jsdoc\"`: Allows trailing whitespace only in JSDoc comments.\n* `\"ignore-blank-lines\"`: Allows trailing whitespace on empty lines.",
+    "hasFix": true,
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "ignore-comments",
+          "ignore-jsdoc",
+          "ignore-template-strings",
+          "ignore-blank-lines"
+        ]
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-comments"
+      ],
+      [
+        true,
+        "ignore-jsdoc"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-typeof-undefined": {
+    "type": "maintainability",
+    "description": "Do not use the idiom typeof `x === 'undefined'`. You can safely use the simpler x === undefined or perhaps x == null if you want to check for either null or undefined.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unbound-method": {
+    "description": "Warns when a method is used as outside of a method call.",
+    "optionsDescription": "You may optionally pass \"ignore-static\" to ignore static methods.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "ignore-static"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-static"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-unexpected-multiline": {
+    "source": "tslint-eslint-rules"
+  },
+  "no-unexternalized-strings": {
+    "type": "maintainability",
+    "description": "Ensures that double quoted strings are passed to a localize call to provide proper strings for different locales",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Configurable",
+    "recommendation": "false, // the VS Code team has a specific localization process that this rule enforces",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-bind": {
+    "type": "maintainability",
+    "description": "Do not bind `this` as the context for a function literal or lambda expression.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-callback-wrapper": {
+    "description": "\nReplaces `x => f(x)` with just `f`.\nTo catch more cases, enable `only-arrow-functions` and `arrow-return-shorthand` too.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-unnecessary-class": {
+    "description": "\nDisallows classes that are not strictly necessary.",
+    "rationale": "\nUsers who come from a Java-style OO language may wrap\ntheir utility functions in an extra class, instead of\nputting them at the top level.",
+    "optionsDescription": "\nThree arguments may be optionally provided:\n\n* `\"allow-constructor-only\"` ignores classes whose members are constructors.\n* `\"allow-empty-class\"` ignores `class DemoClass {}`.\n* `\"allow-static-only\"` ignores classes whose members are static.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minLength": 0,
+      "maxLength": 3
+    },
+    "optionExamples": [
+      true,
+      [
+        "allow-empty-class",
+        "allow-constructor-only"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-unnecessary-field-initialization": {
+    "type": "maintainability",
+    "description": "Do not unnecessarily initialize the fields of a class to values they already have.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-initializer": {
+    "description": "Forbids a 'var'/'let' statement or destructuring initializer to be initialized to 'undefined'.",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-unnecessary-local-variable": {
+    "type": "maintainability",
+    "description": "Do not declare a variable only to return it from the function on the next line.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "563, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-override": {
+    "type": "maintainability",
+    "description": "Do not write a method that only calls super() on the parent method with the same arguments.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-qualifier": {
+    "description": "Warns when a namespace qualifier (`A.x`) is unnecessary.",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-unnecessary-semicolons": {
+    "type": "maintainability",
+    "description": "Remove unnecessary semicolons",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Whitespace",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unnecessary-type-assertion": {
+    "description": "Warns if a type assertion does not change the type of an expression.",
+    "options": {
+      "type": "list",
+      "listType": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "optionsDescription": "A list of whitelisted assertion types to ignore",
+    "type": "typescript",
+    "hasFix": true,
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-unsafe-any": {
+    "description": "\nWarns when using an expression of type 'any' in a dynamic way.\nUses are only allowed if they would work for `{} | null | undefined`.\nType casts and tests are allowed.\nExpressions that work on all values (such as `\"\" + x`) are allowed.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-unsafe-finally": {
+    "description": "\nDisallows control flow statements, such as `return`, `continue`,\n`break` and `throws` in finally blocks.",
+    "descriptionDetails": "",
+    "rationale": "\nWhen used inside `finally` blocks, control flow statements,\nsuch as `return`, `continue`, `break` and `throws`\noverride any other control flow statements in the same try/catch scope.\nThis is confusing and unexpected behavior.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-unsupported-browser-code": {
+    "type": "maintainability",
+    "description": "Avoid writing browser-specific code for unsupported browser versions",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-unused-expression": {
+    "description": "Disallows unused expression statements.",
+    "descriptionDetails": "\nUnused expressions are expression statements which are not assignments or function calls\n(and thus usually no-ops).",
+    "rationale": "\nDetects potential errors where an assignment or function call was intended.",
+    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `allow-fast-null-checks` allows to use logical operators to perform fast null checks and perform\nmethod or function calls for side effects (e.g. `e && e.preventDefault()`).\n* `allow-new` allows 'new' expressions for side effects (e.g. `new ModifyGlobalState();`.\n* `allow-tagged-template` allows tagged templates for side effects (e.g. `this.add\\`foo\\`;`.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-fast-null-checks",
+          "allow-new",
+          "allow-tagged-template"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 3
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-fast-null-checks"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-unused-expression-chai": {
+    "description": "Disallows unused expression statements.",
+    "descriptionDetails": "\nUnused expressions are expression statements which are not assignments or function calls\n(and thus usually no-ops).",
+    "rationale": "\nDetects potential errors where an assignment or function call was intended.",
+    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `allow-fast-null-checks` allows to use logical operators to perform fast null checks and perform\nmethod or function calls for side effects (e.g. `e && e.preventDefault()`).\n* `allow-new` allows 'new' expressions for side effects (e.g. `new ModifyGlobalState();`.\n* `allow-tagged-template` allows tagged templates for side effects (e.g. `this.add\\`foo\\`;`.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-fast-null-checks",
+          "allow-new",
+          "allow-tagged-template"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 3
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-fast-null-checks"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint-no-unused-expression-chai"
+  },
+  "no-unused-variable": {
+    "description": "Disallows unused imports, variables, functions and\n            private class members. Similar to tsc's --noUnusedParameters and --noUnusedLocals\n            options, but does not interrupt code compilation.",
+    "descriptionDetails": "\nIn addition to avoiding compilation errors, this rule may still be useful if you\nwish to have `tslint` automatically remove unused imports, variables, functions,\nand private class members, when using TSLint's `--fix` option.",
+    "hasFix": true,
+    "optionsDescription": "\nThree optional arguments may be optionally provided:\n\n* `\"check-parameters\"` disallows unused function and constructor parameters.\n    * NOTE: this option is experimental and does not work with classes\n    that use abstract method declarations, among other things.\n* `{\"ignore-pattern\": \"pattern\"}` where pattern is a case-sensitive regexp.\nVariable names and imports that match the pattern will be ignored.",
+    "options": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "check-parameters"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ignore-pattern": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 3
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "ignore-pattern": "^_"
+        }
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-use-before-declare": {
+    "description": "Disallows usage of variables before their declaration.",
+    "descriptionDetails": "\nThis rule is primarily useful when using the `var` keyword -\nthe compiler will detect if a `let` and `const` variable is used before it is declared.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "no-useless-files": {
+    "type": "maintainability",
+    "description": "Locates files that only contain commented out code, whitespace characters, or have no content",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": false,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-var-keyword": {
+    "description": "Disallows usage of the `var` keyword.",
+    "descriptionDetails": "Use `let` or `const` instead.",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-var-requires": {
+    "description": "Disallows the use of require statements except in import statements.",
+    "descriptionDetails": "\nIn other words, the use of forms such as `var module = require(\"module\")` are banned.\nInstead use ES6 style imports or `import foo = require('foo')` imports.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "no-var-self": {
+    "type": "maintainability",
+    "description": "Do not use var self = this; instead, manage scope with arrow functions/lambdas.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "no-void-expression": {
+    "description": "Requires expressions of type `void` to appear in statement position.",
+    "optionsDescription": "\nIf `ignore-arrow-function-shorthand` is provided, `() => returnsVoid()` will be allowed.\nOtherwise, it must be written as `() => { returnsVoid(); }`.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "ignore-arrow-function-shorthand"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
+    "requiresTypeInfo": true,
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "no-with-statement": {
+    "type": "maintainability",
+    "description": "Do not use with statements. Assign the item to a new variable instead",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "non-literal-require": {
+    "type": "functionality",
+    "description": "Detect require includes that are not for string literals",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "95,676",
+    "source": "tslint-microsoft-contrib"
+  },
+  "number-literal-format": {
+    "description": "Checks that decimal literals should begin with '0.' instead of just '.', and should not end with a trailing '0'.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "object-curly-spacing": {
+    "source": "tslint-eslint-rules"
+  },
+  "object-literal-key-quotes": {
+    "description": "Enforces consistent object literal property quote style.",
+    "descriptionDetails": "\nObject literal property names can be defined in two ways: using literals or using strings.\nFor example, these two objects are equivalent:\n\nvar object1 = {\n    property: true\n};\n\nvar object2 = {\n    \"property\": true\n};\n\nIn many cases, it doesn’t matter if you choose to use an identifier instead of a string\nor vice-versa. Even so, you might decide to enforce a consistent style in your code.\n\nThis rules lets you enforce consistent quoting of property names. Either they should always\nbe quoted (default behavior) or quoted only as needed (\"as-needed\").",
+    "hasFix": true,
+    "optionsDescription": "\nPossible settings are:\n\n* `\"always\"`: Property names should always be quoted. (This is the default.)\n* `\"as-needed\"`: Only property names which require quotes may be quoted (e.g. those with spaces in them).\n* `\"consistent\"`: Property names should either all be quoted or unquoted.\n* `\"consistent-as-needed\"`: If any property name requires quotes, then all properties must be quoted. Otherwise, no\nproperty names may be quoted.\n\nFor ES6, computed property names (`{[name]: value}`) and methods (`{foo() {}}`) never need\nto be quoted.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "always",
+        "as-needed",
+        "consistent",
+        "consistent-as-needed"
+      ]
+    },
+    "optionExamples": [
+      [
+        true,
+        "as-needed"
+      ],
+      [
+        true,
+        "always"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "object-literal-shorthand": {
+    "description": "Enforces/disallows use of ES6 object literal shorthand.",
+    "hasFix": true,
+    "optionsDescription": "\nIf the 'never' option is provided, any shorthand object literal syntax will cause a failure.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "never"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "never"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "object-literal-sort-keys": {
+    "description": "\nChecks ordering of keys in object literals.\n\nWhen using the default alphabetical ordering, additional blank lines may be used to group\nobject properties together while keeping the elements within each group in alphabetical order.\n        ",
+    "rationale": "Useful in preventing merge conflicts",
+    "optionsDescription": "\nBy default, this rule checks that keys are in alphabetical order.\nThe following may optionally be passed:\n\n* \"ignore-case\" will to compare keys in a case insensitive way.\n* \"match-declaration-order\" will prefer to use the key ordering of the contextual type of the object literal, as in:\n\n    interface I { foo: number; bar: number; }\n    const obj: I = { foo: 1, bar: 2 };\n\nIf a contextual type is not found, alphabetical ordering will be used instead.\n",
+    "options": {
+      "type": "string",
+      "enum": [
+        "ignore-case",
+        "match-declaration-order"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-case",
+        "match-declaration-order"
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "one-line": {
+    "description": "Requires the specified tokens to be on the same line as the expression preceding them.",
+    "optionsDescription": "\nFive arguments may be optionally provided:\n\n* `\"check-catch\"` checks that `catch` is on the same line as the closing brace for `try`.\n* `\"check-finally\"` checks that `finally` is on the same line as the closing brace for `catch`.\n* `\"check-else\"` checks that `else` is on the same line as the closing brace for `if`.\n* `\"check-open-brace\"` checks that an open brace falls on the same line as its preceding expression.\n* `\"check-whitespace\"` checks preceding whitespace for the specified tokens.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "check-catch",
+          "check-finally",
+          "check-else",
+          "check-open-brace",
+          "check-whitespace"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      [
+        true,
+        "check-catch",
+        "check-finally",
+        "check-else"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "one-variable-per-declaration": {
+    "description": "Disallows multiple variable definitions in the same declaration statement.",
+    "optionsDescription": "\nOne argument may be optionally provided:\n\n* `ignore-for-loop` allows multiple variable definitions in a for loop declaration.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "ignore-for-loop"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "ignore-for-loop"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "only-arrow-functions": {
+    "description": "Disallows traditional (non-arrow) function expressions.",
+    "rationale": "Traditional functions don't bind lexical scope, which can lead to unexpected behavior when accessing 'this'.",
+    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `\"allow-declarations\"` allows standalone function declarations.\n* `\"allow-named-functions\"` allows the expression `function foo() {}` but not `function() {}`.\n        ",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-declarations",
+          "allow-named-functions"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 1
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-declarations",
+        "allow-named-functions"
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "ordered-imports": {
+    "description": "Requires that import statements be alphabetized and grouped.",
+    "descriptionDetails": "\nEnforce a consistent ordering for ES6 imports:\n- Named imports must be alphabetized (i.e. \"import {A, B, C} from \"foo\";\")\n    - The exact ordering can be controlled by the named-imports-order option.\n    - \"longName as name\" imports are ordered by \"longName\".\n- Import sources must be alphabetized within groups, i.e.:\n        import * as foo from \"a\";\n        import * as bar from \"b\";\n- Groups of imports are delineated by blank lines. You can use these to group imports\n    however you like, e.g. by first- vs. third-party or thematically or can you can\n    enforce a grouping of third-party, parent directories and the current directory.",
+    "hasFix": true,
+    "optionsDescription": "\nYou may set the `\"import-sources-order\"` option to control the ordering of source\nimports (the `\"foo\"` in `import {A, B, C} from \"foo\"`).\n\nPossible values for `\"import-sources-order\"` are:\n\n* `\"case-insensitive'`: Correct order is `\"Bar\"`, `\"baz\"`, `\"Foo\"`. (This is the default.)\n* `\"lowercase-first\"`: Correct order is `\"baz\"`, `\"Bar\"`, `\"Foo\"`.\n* `\"lowercase-last\"`: Correct order is `\"Bar\"`, `\"Foo\"`, `\"baz\"`.\n* `\"any\"`: Allow any order.\n\nYou may set the `\"grouped-imports\"` option to control the grouping of source\nimports (the `\"foo\"` in `import {A, B, C} from \"foo\"`).\n\nPossible values for `\"grouped-imports\"` are:\n\n* `false`: Do not enforce grouping. (This is the default.)\n* `true`: Group source imports by `\"bar\"`, `\"../baz\"`, `\"./foo\"`.\n\nYou may set the `\"named-imports-order\"` option to control the ordering of named\nimports (the `{A, B, C}` in `import {A, B, C} from \"foo\"`).\n\nPossible values for `\"named-imports-order\"` are:\n\n* `\"case-insensitive'`: Correct order is `{A, b, C}`. (This is the default.)\n* `\"lowercase-first\"`: Correct order is `{b, A, C}`.\n* `\"lowercase-last\"`: Correct order is `{A, C, b}`.\n* `\"any\"`: Allow any order.\n\nYou may set the `\"module-source-path\"` option to control the ordering of imports based full path\nor just the module name\n\nPossible values for `\"module-source-path\"` are:\n\n* `\"full'`: Correct order is  `\"./a/Foo\"`, `\"./b/baz\"`, `\"./c/Bar\"`. (This is the default.)\n* `\"basename\"`: Correct order is `\"./c/Bar\"`, `\"./b/baz\"`, `\"./a/Foo\"`.\n\n        ",
+    "options": {
+      "type": "object",
+      "properties": {
+        "grouped-imports": {
+          "type": "boolean"
+        },
+        "import-sources-order": {
+          "type": "string",
+          "enum": [
+            "case-insensitive",
+            "lowercase-first",
+            "lowercase-last",
+            "any"
+          ]
+        },
+        "named-imports-order": {
+          "type": "string",
+          "enum": [
+            "case-insensitive",
+            "lowercase-first",
+            "lowercase-last",
+            "any"
+          ]
+        },
+        "module-source-path": {
+          "type": "string",
+          "enum": [
+            "full",
+            "basename"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "import-sources-order": "lowercase-last",
+          "named-imports-order": "lowercase-first"
+        }
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "possible-timing-attack": {
+    "type": "functionality",
+    "description": "Avoid timing attacks by not making direct comaprisons to sensitive data",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Security",
+    "commonWeaknessEnumeration": "710,749",
+    "source": "tslint-microsoft-contrib"
+  },
+  "prefer-array-literal": {
+    "type": "maintainability",
+    "description": "Use array literal syntax when declaring or instantiating array types.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "prefer-conditional-expression": {
+    "description": "\nRecommends to use a conditional expression instead of assigning to the same thing in each branch of an if statement.",
+    "rationale": "\nThis reduces duplication and can eliminate an unnecessary variable declaration.",
+    "optionsDescription": "If `check-else-if` is specified, the rule also checks nested if-else-if statements.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "check-else-if"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "check-else-if"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-const": {
+    "description": "Requires that variable declarations use `const` instead of `let` and `var` if possible.",
+    "descriptionDetails": "\nIf a variable is only assigned to once when it is declared, it should be declared using 'const'",
+    "hasFix": true,
+    "optionsDescription": "\nAn optional object containing the property \"destructuring\" with two possible values:\n\n* \"any\" (default) - If any variable in destructuring can be const, this rule warns for those variables.\n* \"all\" - Only warns if all variables in destructuring can be const.",
+    "options": {
+      "type": "object",
+      "properties": {
+        "destructuring": {
+          "type": "string",
+          "enum": [
+            "all",
+            "any"
+          ]
+        }
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "destructuring": "all"
+        }
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-for-of": {
+    "description": "Recommends a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.",
+    "rationale": "A for(... of ...) loop is easier to implement and read when the index is not needed.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-function-over-method": {
+    "description": "Warns for class methods that do not use 'this'.",
+    "optionsDescription": "\n\"allow-public\" excludes checking of public methods.\n\"allow-protected\" excludes checking of protected methods.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "allow-public",
+        "allow-protected"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-public",
+        "allow-protected"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-method-signature": {
+    "description": "Prefer `foo(): void` over `foo: () => void` in interfaces and types.",
+    "hasFix": true,
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-object-spread": {
+    "description": "Enforces the use of the ES2015 object spread operator over `Object.assign()` where appropriate.",
+    "rationale": "Object spread allows for better type checking and inference.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "prefer-switch": {
+    "description": "Prefer a `switch` statement to an `if` statement with simple `===` comparisons.",
+    "optionsDescription": "\nAn optional object with the property 'min-cases'.\nThis is the number cases needed before a switch statement is recommended.\nDefaults to 3.",
+    "options": {
+      "type": "object",
+      "properties": {
+        "min-cases": {
+          "type": "number"
+        }
+      }
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        {
+          "min-cases": 2
+        }
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-template": {
+    "description": "Prefer a template expression over string literal concatenation.",
+    "optionsDescription": "\nIf `allow-single-concat` is specified, then a single concatenation (`x + y`) is allowed, but not more (`x + y + z`).",
+    "options": {
+      "type": "string",
+      "enum": [
+        "allow-single-concat"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-single-concat"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "prefer-type-cast": {
+    "type": "maintainability",
+    "description": "Prefer the tradition type casts instead of the new 'as-cast' syntax",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Configurable",
+    "recommendation": "true,   // pick either type-cast format and use it consistently",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "promise-function-async": {
+    "description": "Requires any function or method that returns a promise to be marked async.",
+    "rationale": "\nEnsures that each function is only capable of 1) returning a rejected promise, or 2)\nthrowing an Error object. In contrast, non-`async` `Promise`-returning functions\nare technically capable of either. This practice removes a requirement for consuming\ncode to handle both cases.\n        ",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "promise-must-complete": {
+    "type": "maintainability",
+    "description": "When a Promise instance is created, then either the reject() or resolve() parameter must be called on it within all code branches in the scope.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "quotemark": {
+    "description": "Requires single or double quotes for string literals.",
+    "hasFix": true,
+    "optionsDescription": "\nFive arguments may be optionally provided:\n\n* `\"single\"` enforces single quotes.\n* `\"double\"` enforces double quotes.\n* `\"jsx-single\"` enforces single quotes for JSX attributes.\n* `\"jsx-double\"` enforces double quotes for JSX attributes.\n* `\"avoid-template\"` forbids single-line untagged template strings that do not contain string interpolations.\n* `\"avoid-escape\"` allows you to use the \"other\" quotemark in cases where escaping would normally be required.\nFor example, `[true, \"double\", \"avoid-escape\"]` would not report a failure on the string literal\n`'Hello \"World\"'`.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "single",
+          "double",
+          "jsx-single",
+          "jsx-double",
+          "avoid-escape",
+          "avoid-template"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      [
+        true,
+        "single",
+        "avoid-escape",
+        "avoid-template"
+      ],
+      [
+        true,
+        "single",
+        "jsx-double"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "radix": {
+    "description": "Requires the radix parameter to be specified when calling `parseInt`.",
+    "rationale": "\nFrom [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt):\n> Always specify this parameter to eliminate reader confusion and to guarantee predictable behavior.\n> Different implementations produce different results when a radix is not specified, usually defaulting the value to 10.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "react-a11y-anchors": {
+    "type": "functionality",
+    "description": "For accessibility of your website, anchor elements must have a href different from # and a text longer than 4.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-aria-unsupported-elements": {
+    "type": "maintainability",
+    "description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-event-has-role": {
+    "type": "maintainability",
+    "description": "Elements with event handlers must have role attribute.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-image-button-has-alt": {
+    "type": "maintainability",
+    "description": "Enforce that inputs element with type=\"image\" must have alt attribute.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-img-has-alt": {
+    "type": "maintainability",
+    "description": "Enforce that an img element contains the non-empty alt attribute. For decorative images, using empty alt attribute and role=\"presentation\".",
+    "options": "string[]",
+    "optionsDescription": "",
+    "optionExamples": [
+      "true",
+      "[true, [\"Image\"]]"
+    ],
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-lang": {
+    "type": "functionality",
+    "description": "For accessibility of your website, html elements must have a valid lang attribute.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-meta": {
+    "type": "functionality",
+    "description": "For accessibility of your website, HTML meta elements must not have http-equiv=\"refresh\".",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Ignored",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-props": {
+    "type": "maintainability",
+    "description": "Enforce all `aria-*` attributes are valid. Elements cannot use an invalid `aria-*` attribute.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-proptypes": {
+    "type": "maintainability",
+    "description": "Enforce ARIA state and property values are valid.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role": {
+    "type": "maintainability",
+    "description": "Elements with aria roles must use a **valid**, **non-abstract** aria role.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role-has-required-aria-props": {
+    "type": "maintainability",
+    "description": "Elements with aria roles must have all required attributes according to the role.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-role-supports-aria-props": {
+    "type": "maintainability",
+    "description": "Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-tabindex-no-positive": {
+    "type": "maintainability",
+    "description": "Enforce tabindex value is **not greater than zero**.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-a11y-titles": {
+    "type": "functionality",
+    "description": "For accessibility of your website, HTML title elements must be concise and non-empty.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Moderate",
+    "level": "Opportunity for Excellence",
+    "group": "Accessibility",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-anchor-blank-noopener": {
+    "type": "functionality",
+    "description": "Anchor tags with target=\"_blank\" should also include rel=\"noopener noreferrer\"",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "242,676",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-iframe-missing-sandbox": {
+    "type": "functionality",
+    "description": "React iframes must specify a sandbox attribute",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Security",
+    "commonWeaknessEnumeration": "915",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-no-dangerous-html": {
+    "type": "maintainability",
+    "description": "Do not use React's dangerouslySetInnerHTML API.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Mandatory",
+    "group": "Security",
+    "commonWeaknessEnumeration": "79, 85, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-this-binding-issue": {
+    "type": "maintainability",
+    "description": "When using React components you must be careful to correctly bind the `this` reference on any methods that you pass off to child components as callbacks.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Error",
+    "severity": "Critical",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-tsx-curly-spacing": {
+    "type": "style",
+    "description": "Consistently use spaces around the brace characters of JSX attributes.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Whitespace",
+    "source": "tslint-microsoft-contrib"
+  },
+  "react-unused-props-and-state": {
+    "type": "maintainability",
+    "description": "Remove unneeded properties defined in React Props and State interfaces",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "398",
+    "source": "tslint-microsoft-contrib"
+  },
+  "restrict-plus-operands": {
+    "description": "When adding two variables, operands must both be of type number or of type string.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "return-undefined": {
+    "description": "Prefer `return;` in void functions and `return undefined;` in value-returning functions.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "semicolon": {
+    "description": "Enforces consistent semicolon usage at the end of every statement.",
+    "hasFix": true,
+    "optionsDescription": "\nOne of the following arguments must be provided:\n\n* `\"always\"` enforces semicolons at the end of every statement.\n* `\"never\"` disallows semicolons at the end of every statement except for when they are necessary.\n\nThe following arguments may be optionally provided:\n\n* `\"ignore-interfaces\"` skips checking semicolons at the end of interface members.\n* `\"ignore-bound-class-methods\"` skips checking semicolons at the end of bound class methods.\n* `\"strict-bound-class-methods\"` disables any special handling of bound class methods and treats them as any\nother assignment. This option overrides `\"ignore-bound-class-methods\"`.\n        ",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string",
+          "enum": [
+            "always",
+            "never"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "ignore-interfaces"
+          ]
+        }
+      ],
+      "additionalItems": false
+    },
+    "optionExamples": [
+      [
+        true,
+        "always"
+      ],
+      [
+        true,
+        "never"
+      ],
+      [
+        true,
+        "always",
+        "ignore-interfaces"
+      ],
+      [
+        true,
+        "always",
+        "ignore-bound-class-methods"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "sort-imports": {
+    "description": "enforce sorting import declarations within module",
+    "rationale": "\nWhen declaring multiple imports, a sorted list of import declarations make it easier for developers to\nread the code and find necessary imports later. This rule is purely a matter of style.\n\nThis rule checks all import declarations and verifies that all imports are first sorted by the used member\nsyntax and then alphabetically by the first member or alias name.\n",
+    "optionsDescription": "\n- `\"ignore-case\"` does case-insensitive comparisons (default: `false`)\n- `\"ignore-member-sort\"` allows members in multiple type imports to occur in any order (default: `false`)\n- `\"member-syntax-sort-order\"` (default: `[\"none\", \"all\", \"multiple\", \"single\", \"alias\"]`); all 5 items must be\npresent in the array, but you can change the order:\n  - `none` = import module without exported bindings.\n  - `all` = import all members provided by exported bindings.\n  - `multiple` = import multiple members.\n  - `single` = import a single member.\n  - `alias` = creates an alias for a member. This is unique to TER and not in ESLint's `sort-imports`.\n",
+    "options": {
+      "type": "object",
+      "properties": {
+        "member-syntax-sort-order": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "none",
+              "all",
+              "multiple",
+              "single",
+              "alias"
+            ]
+          },
+          "minLength": 5,
+          "maxLength": 5
+        },
+        "ignore-case": {
+          "type": "boolean"
+        },
+        "ignore-member-sort": {
+          "type": "boolean"
+        }
+      }
+    },
+    "optionExamples": [
+      "\n\"sort-imports\": [true]\n",
+      "\n\"sort-imports\": [true, { \"ignore-case\" }]\n",
+      "\n\"sort-imports\": [true, { \"ignore-member-sort\" }]\n",
+      "\n\"sort-imports\": [true, { \"member-syntax-sort-order\": [\"all\", \"single\", \"multiple\", \"none\", \"alias\"] }]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "space-before-function-paren": {
+    "description": "Require or disallow a space before function parenthesis",
+    "hasFix": true,
+    "optionExamples": [
+      true,
+      [
+        true,
+        "always"
+      ],
+      [
+        true,
+        "never"
+      ],
+      [
+        true,
+        {
+          "anonymous": "always",
+          "named": "never",
+          "asyncArrow": "always"
+        }
+      ]
+    ],
+    "options": {
+      "properties": {
+        "anonymous": {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        },
+        "asyncArrow": {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        },
+        "constructor": {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        },
+        "named": {
+          "enum": [
+            "always",
+            "never"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "optionsDescription": "\nOne argument which is an object which may contain the keys `anonymous`, `named`, and `asyncArrow`\nThese should be set to either `\"always\"` or `\"never\"`.\n\n* `\"anonymous\"` checks before the opening paren in anonymous functions\n* `\"named\"` checks before the opening paren in named functions\n* `\"asyncArrow\"` checks before the opening paren in async arrow functions\n* `\"method\"` checks before the opening paren in class methods\n* `\"constructor\"` checks before the opening paren in class constructors\n        ",
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "space-in-parens": {
+    "description": "require or disallow spaces inside parentheses",
+    "rationale": "\nThis rule will enforce consistency of spacing directly inside of parentheses,\nby disallowing or requiring one or more spaces to the right of (and to the\nleft of). In either case, () will still be allowed.\n",
+    "optionsDescription": "\nThere are two options for this rule:\n\n- `\"never\"` (default) enforces zero spaces inside of parentheses\n- `\"always\"` enforces a space inside of parentheses\n\nDepending on your coding conventions, you can choose either option by specifying\nit in your configuration.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "never"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exceptions": {
+              "type": "array",
+              "items": [
+                {
+                  "enum": [
+                    "{}",
+                    "[]",
+                    "()",
+                    "empty"
+                  ]
+                }
+              ],
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 2
+    },
+    "optionExamples": [
+      "\n\"space-in-parens\": [true, \"always\"]\n",
+      "\n\"space-in-parens\": [true, \"never\"]\n",
+      "\n\"space-in-parens\": [true, \"always\", { \"exceptions\": [ \"{}\", \"[]\", \"()\", \"empty\" ] }]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "space-within-parens": {
+    "description": "Enforces spaces within parentheses or disallow them.",
+    "hasFix": true,
+    "optionsDescription": "\nYou may enforce the amount of whitespace within parentheses.\n        ",
+    "options": {
+      "type": "number",
+      "min": 0
+    },
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "strict-boolean-expressions": {
+    "description": "\nRestricts the types allowed in boolean expressions. By default only booleans are allowed.\n\nThe following nodes are checked:\n\n* Arguments to the `!`, `&&`, and `||` operators\n* The condition in a conditional expression (`cond ? x : y`)\n* Conditions for `if`, `for`, `while`, and `do-while` statements.",
+    "optionsDescription": "\nThese options may be provided:\n\n* `allow-null-union` allows union types containing `null`.\n  - It does *not* allow `null` itself.\n  - Without the '--strictNullChecks' compiler option, this will allow anything other than a string, number, or enum.\n* `allow-undefined-union` allows union types containing `undefined`.\n  - It does *not* allow `undefined` itself.\n  - Without the '--strictNullChecks' compiler option, this will allow anything other than a string, number, or enum.\n* `allow-string` allows strings.\n  - It does *not* allow unions containing `string`.\n  - It does *not* allow string literal types.\n* `allow-number` allows numbers.\n  - It does *not* allow unions containing `number`.\n  - It does *not* allow enums or number literal types.\n* `allow-mix` allows multiple of the above to appear together.\n  - For example, `string | number` or `RegExp | null | undefined` would normally not be allowed.\n  - A type like `\"foo\" | \"bar\" | undefined` is always allowed, because it has only one way to be false.\n* `allow-boolean-or-undefined` allows `boolean | undefined`.\n  - Also allows `true | false | undefined`.\n  - Does not allow `false | undefined`.\n  - This option is a subset of `allow-undefined-union`, so you don't need to enable both options at the same time.\n        ",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-null-union",
+          "allow-undefined-union",
+          "allow-string",
+          "allow-number",
+          "allow-boolean-or-undefined"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-null-union",
+        "allow-undefined-union",
+        "allow-string",
+        "allow-number"
+      ],
+      [
+        true,
+        "allow-boolean-or-undefined"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "strict-type-predicates": {
+    "description": "\nWarns for type predicates that are always true or always false.\nWorks for 'typeof' comparisons to constants (e.g. 'typeof foo === \"string\"'), and equality comparison to 'null'/'undefined'.\n(TypeScript won't let you compare '1 === 2', but it has an exception for '1 === undefined'.)\nDoes not yet work for 'instanceof'.\nDoes *not* warn for 'if (x.y)' where 'x.y' is always truthy. For that, see strict-boolean-expressions.\n\nThis rule requires `strictNullChecks` to work properly.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "switch-default": {
+    "description": "Require a `default` case in all `switch` statements.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "switch-final-break": {
+    "description": "Checks whether the final clause of a switch statement ends in `break;`.",
+    "optionsDescription": "\nIf no options are passed, a final 'break;' is forbidden.\nIf the \"always\" option is passed this will require a 'break;' to always be present\nunless control flow is escaped in some other way.",
+    "options": {
+      "type": "string",
+      "enum": [
+        "always"
+      ]
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "always"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "ter-arrow-body-style": {
+    "description": "require braces in arrow function body",
+    "rationale": "\nArrow functions have two syntactic forms for their function bodies. They may be defined with\na block body (denoted by curly braces) `() => { ... }` or with a single expression\n`() => ...`, whose value is implicitly returned.\n",
+    "optionsDescription": "\nThe rule takes one or two options. The first is a string, which can be:\n\n- `\"always\"` enforces braces around the function body\n- `\"as-needed\"` enforces no braces where they can be omitted (default)\n- `\"never\"` enforces no braces around the function body (constrains arrow functions to the\n              role of returning an expression)\n\nThe second one is an object for more fine-grained configuration when the first option is\n`\"as-needed\"`. Currently, the only available option is `requireReturnForObjectLiteral`, a\nboolean property. It’s false by default. If set to true, it requires braces and an explicit\nreturn for object literals.\n",
+    "options": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "enum": [
+                "always",
+                "never"
+              ]
+            }
+          ],
+          "minItems": 0,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "items": [
+            {
+              "enum": [
+                "as-needed"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "requireReturnForObjectLiteral": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "minItems": 0,
+          "maxItems": 2
+        }
+      ]
+    },
+    "optionExamples": [
+      "\n\"ter-arrow-body-style\": [true, \"always\"]\n",
+      "\n\"ter-arrow-body-style\": [true, \"never\"]\n",
+      "\n\"ter-arrow-body-style\": [true, \"as-needed\", {\n  \"requireReturnForObjectLiteral\": true\n}]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-arrow-parens": {
+    "description": "require parens in arrow function arguments",
+    "rationale": "\nArrow functions can omit parentheses when they have exactly one parameter. In all other cases\nthe parameter(s) must be wrapped in parentheses. This rule enforces the consistent use of\nparentheses in arrow functions.\n",
+    "optionsDescription": "\nThis rule has a string option and an object one.\n\nString options are:\n\n- `\"always\"` (default) requires parentheses around arguments in all cases.\n- `\"as-needed\"` allows omitting parentheses when there is only one argument.\n\nObject properties for variants of the `\"as-needed\"` option:\n\n- `\"requireForBlockBody\": true` modifies the as-needed rule in order to require\n  parentheses if the function body is in an instructions block (surrounded by braces).\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "as-needed"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "requireForBlockBody": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "\n\"ter-arrow-parens\": [true]\n",
+      "\n\"ter-arrow-parens\": [true, \"always\"]\n",
+      "\n\"ter-arrow-parens\": [true, \"as-needed\"]\n",
+      "\n\"ter-arrow-parens\": [true, \"as-needed\", { \"requireForBlockBody\": true }]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-arrow-spacing": {
+    "description": "require space before/after arrow function's arrow",
+    "rationale": "\nThis rule normalizes the style of spacing before/after an arrow function’s arrow(`=>`).\n",
+    "optionsDescription": "\nThis rule takes an object argument with `before` and `after` properties, each with a\nBoolean value.\n\nThe default configuration is `{ \"before\": true, \"after\": true }`.\n\n`true` means there should be one or more spaces and `false` means no spaces.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "before": {
+              "type": "boolean"
+            },
+            "after": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "\n\"ter-arrow-spacing\": [true]\n",
+      "\n\"ter-arrow-spacing\": [true, {\n  \"before\": false,\n  \"after\": false\n}]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-func-call-spacing": {
+    "hasFix": true,
+    "description": "require or disallow spacing between function identifiers and their invocations",
+    "rationale": "\nThis rule will enforce consistency of spacing in function calls,\nby disallowing or requiring one or more spaces before the open paren.\n",
+    "optionsDescription": "\nThis rule has a string option:\n\n* `\"never\"` (default) disallows space between the function name and the opening parenthesis.\n* `\"always\"` requires space between the function name and the opening parenthesis.\n\nFurther, in `\"always\"` mode, a second object option is available that contains a single boolean `allowNewlines` property.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "enum": [
+            "always",
+            "never"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "allowNewlines": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 2
+    },
+    "optionExamples": [
+      "\n\"ter-func-call-spacing\": [true]\n",
+      "\n\"ter-func-call-spacing\": [true, \"always\"]\n",
+      "\n\"ter-func-call-spacing\": [true, \"always\", { allowNewlines: true }]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-indent": {
+    "hasFix": true,
+    "description": "enforce consistent indentation",
+    "rationale": "\nUsing only one of tabs or spaces for indentation leads to more consistent editor behavior,\ncleaner diffs in version control, and easier programmatic manipulation.\n",
+    "optionsDescription": "\nThe string 'tab' or an integer indicating the number of spaces to use per tab.\n\nAn object may be provided to fine tune the indentation rules:\n\n  * `\"SwitchCase\"` (default: 0) enforces indentation level for `case` clauses in\n                     `switch` statements\n  * `\"VariableDeclarator\"` (default: 1) enforces indentation level for `var` declarators;\n                             can also take an object to define separate rules for `var`,\n                             `let` and `const` declarations.\n  * `\"outerIIFEBody\"` (default: 1) enforces indentation level for file-level IIFEs.\n  * `\"MemberExpression\"` (off by default) enforces indentation level for multi-line\n                           property chains (except in variable declarations and assignments)\n  * `\"FunctionDeclaration\"` takes an object to define rules for function declarations.\n      * `\"parameters\"` (off by default) enforces indentation level for parameters in a\n                         function declaration. This can either be a number indicating\n                         indentation level, or the string `\"first\"` indicating that all\n                         parameters of the declaration must be aligned with the first parameter.\n      * `\"body\"` (default: 1) enforces indentation level for the body of a function expression.\n  * `\"FunctionExpression\"` takes an object to define rules for function declarations.\n      * `\"parameters\"` (off by default) enforces indentation level for parameters in a\n                         function declaration. This can either be a number indicating\n                         indentation level, or the string `\"first\"` indicating that all\n                         parameters of the declaration must be aligned with the first parameter.\n      * `\"body\"` (default: 1) enforces indentation level for the body of a function expression.\n  * `\"CallExpression\"` takes an object to define rules for function call expressions.\n      * `\"arguments\"` (off by default) enforces indentation level for arguments in a call\n                        expression. This can either be a number indicating indentation level,\n                        or the string `\"first\"` indicating that all arguments of the\n                        expression must be aligned with the first argument.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "number",
+          "minimum": "0"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "tab"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "SwitchCase": {
+              "type": "number",
+              "minimum": 0
+            },
+            "VariableDeclarator": {
+              "type": "object",
+              "properties": {
+                "var": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "let": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "const": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              }
+            },
+            "outerIIFEBody": {
+              "type": "number"
+            },
+            "FunctionDeclaration": {
+              "type": "object",
+              "properties": {
+                "parameters": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "body": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              }
+            },
+            "FunctionExpression": {
+              "type": "object",
+              "properties": {
+                "parameters": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "body": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              }
+            },
+            "MemberExpression": {
+              "type": "number"
+            },
+            "CallExpression": {
+              "type": "object",
+              "properties": {
+                "arguments": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minLength": 1,
+      "maxLength": 2
+    },
+    "optionExamples": [
+      "\n\"ter-indent\": [true, \"tab\"]\n",
+      "\n\"ter-indent\": [true, 2]\n",
+      "\n\"ter-indent\": [\n  true,\n  2,\n  {\n    \"FunctionExpression\": {\n      \"parameters\": 1,\n      \"body\": 1\n    }\n  }\n]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "maintainability",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-max-len": {
+    "description": "enforce a maximum line length",
+    "rationale": "\nLimiting the length of a line of code improves code readability.\nIt also makes comparing code side-by-side easier and improves compatibility with\nvarious editors, IDEs, and diff viewers.\n",
+    "optionsDescription": "\nAn integer indicating the maximum length of lines followed by an optional integer specifying\nthe character width for tab characters.\n\nAn optional object may be provided to fine tune the rule:\n\n* `\"code\"`: (default 80) enforces a maximum line length\n* `\"tabWidth\"`: (default 4) specifies the character width for tab characters\n* `\"comments\"`: enforces a maximum line length for comments; defaults to value of code\n* `\"ignorePattern\"`: ignores lines matching a regular expression; can only match a single\n                           line and need to be double escaped when written in JSON\n* `\"ignoreComments\"`: true ignores all trailing comments and comments on their own line\n* `\"ignoreTrailingComments\"`: true ignores only trailing comments\n* `\"ignoreUrls\"`: true ignores lines that contain a URL\n* `\"ignoreStrings\"`: true ignores lines that contain a double-quoted or single-quoted string\n* `\"ignoreTemplateLiterals\"`: true ignores lines that contain a template literal\n* `\"ignoreRegExpLiterals\"`: true ignores lines that contain a RegExp literal\n* `\"ignoreImports\"`: true ignores lines that contain an import module specifier\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "number",
+          "minimum": "0"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "number",
+              "minumum": "1"
+            },
+            "comments": {
+              "type": "number",
+              "minumum": "1"
+            },
+            "tabWidth": {
+              "type": "number",
+              "minumum": "1"
+            },
+            "ignorePattern": {
+              "type": "string"
+            },
+            "ignoreComments": {
+              "type": "boolean"
+            },
+            "ignoreStrings": {
+              "type": "boolean"
+            },
+            "ignoreUrls": {
+              "type": "boolean"
+            },
+            "ignoreTemplateLiterals": {
+              "type": "boolean"
+            },
+            "ignoreRegExpLiterals": {
+              "type": "boolean"
+            },
+            "ignoreTrailingComments": {
+              "type": "boolean"
+            },
+            "ignoreImports": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minLength": 1,
+      "maxLength": 3
+    },
+    "optionExamples": [
+      "\n\"ter-max-len\": [true, 100]\n",
+      "\n\"ter-max-len\": [\n  true,\n  100,\n  2,\n  {\n    \"ignoreUrls\": true,\n    \"ignorePattern\": \"^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\(\"\n  }\n]\n",
+      "\n\"ter-max-len\": [\n  true,\n  {\n    \"code\": 100,\n    \"tabWidth\": 2,\n    \"ignoreImports\": true,\n    \"ignoreUrls\": true,\n    \"ignorePattern\": \"^\\\\s*(let|const)\\\\s.+=\\\\s*require\\\\s*\\\\(\"\n  }\n]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "style",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-no-irregular-whitespace": {
+    "description": "disallow irregular whitespace (recommended)",
+    "rationale": "\nInvalid or irregular whitespace causes issues with ECMAScript 5 parsers and also makes code\nharder to debug in a similar nature to mixed tabs and spaces.\n",
+    "optionsDescription": "",
+    "options": {},
+    "optionExamples": [
+      "\n\"ter-no-irregular-whitespace\": [true]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "typescript",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-no-sparse-arrays": {
+    "description": "disallow sparse arrays (recommended)",
+    "rationale": "\nInvalid or irregular whitespace causes issues with ECMAScript 5 parsers and also makes code\nharder to debug in a similar nature to mixed tabs and spaces.\n",
+    "optionsDescription": "",
+    "options": {},
+    "optionExamples": [
+      "\n\"ter-no-sparse-arrays\": [true]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "typescript",
+    "source": "tslint-eslint-rules"
+  },
+  "ter-prefer-arrow-callback": {
+    "description": "require arrow functions as callbacks",
+    "rationale": "\nArrow functions are suited to callbacks, because:\n\n* `this` keywords in arrow functions bind to the upper scope’s.\n* The notation of the arrow function is shorter than function expression’s.\n",
+    "optionsDescription": "\nThis rule takes one optional argument, an object which is an options object. This object\nmay specify the following properties:\n\n* `\"allowNamedFunctions\"` (default false) When set to `true`, the rule doesn't warn on\n                            named functions used as callback.\n* `\"allowUnboundThis\"` (default true) When set to `false`, this option allows the use of\n                         `this` without restriction and checks for dynamically assigned\n                         `this` values such as when using `Array.prototype.map` with a\n                         `context` argument. Normally, the rule will flag the use of this\n                         whenever a function does not use `bind()` to specify the value of\n                         `this` constantly.\n",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "allowNamedFunctions": {
+              "type": "boolean"
+            },
+            "allowUnboundThis": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "maxLength": 1
+    },
+    "optionExamples": [
+      "\n\"ter-prefer-arrow-callback\": [true]\n",
+      "\n\"ter-prefer-arrow-callback\": [true, {\n  \"allowNamedFunctions\": true\n}]\n",
+      "\n\"ter-prefer-arrow-callback\": [true, {\n  \"allowUnboundThis\": false\n}]\n",
+      "\n\"ter-prefer-arrow-callback\": [true, {\n  \"allowNamedFunctions\": true,\n  \"allowUnboundThis\": false\n}]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "typescript",
+    "source": "tslint-eslint-rules"
+  },
+  "trailing-comma": {
+    "description": "\nRequires or disallows trailing commas in array and object literals, destructuring assignments, function typings,\nnamed imports and exports and function parameters.",
+    "hasFix": true,
+    "optionsDescription": "\nOne argument which is an object with the keys `multiline` and `singleline`.\nBoth can be set to a string (`\"always\"` or `\"never\"`) or an object.\n\nThe object can contain any of the following keys: `\"arrays\"`, `\"objects\"`, `\"functions\"`,\n`\"imports\"`, `\"exports\"`, and `\"typeLiterals\"`; each key can have one of the following\nvalues: `\"always\"`, `\"never\"`, and `\"ignore\"`. Any missing keys will default to `\"ignore\"`.\n\n* `\"multiline\"` checks multi-line object literals.\n* `\"singleline\"` checks single-line object literals.\n\nAn array is considered \"multiline\" if its closing bracket is on a line\nafter the last array element. The same general logic is followed for\nobject literals, function typings, named import statements\nand function parameters.\n\nTo align this rule with the ECMAScript specification that is implemented in modern JavaScript VMs,\nthere is a third option `esSpecCompliant`. Set this option to `true` to disallow trailing comma on\nobject and array rest and rest parameters.\n        ",
+    "options": {
+      "type": "object",
+      "properties": {
+        "multiline": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "always",
+                "never"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "arrays": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "exports": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "functions": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "imports": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "objects": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "typeLiterals": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "singleline": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "always",
+                "never"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "arrays": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "exports": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "functions": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "imports": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "objects": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                },
+                "typeLiterals": {
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never",
+                    "ignore"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "esSpecCompliant": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionExamples": [
+      [
+        true,
+        {
+          "multiline": "always",
+          "singleline": "never"
+        }
+      ],
+      [
+        true,
+        {
+          "multiline": {
+            "objects": "always",
+            "arrays": "always",
+            "functions": "never",
+            "typeLiterals": "ignore"
+          },
+          "esSpecCompliant": true
+        }
+      ]
+    ],
+    "type": "maintainability",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "triple-equals": {
+    "description": "Requires `===` and `!==` in place of `==` and `!=`.",
+    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `\"allow-null-check\"` allows `==` and `!=` when comparing to `null`.\n* `\"allow-undefined-check\"` allows `==` and `!=` when comparing to `undefined`.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "allow-null-check",
+          "allow-undefined-check"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 2
+    },
+    "optionExamples": [
+      true,
+      [
+        true,
+        "allow-null-check"
+      ],
+      [
+        true,
+        "allow-undefined-check"
+      ]
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "type-literal-delimiter": {
+    "description": "\nChecks that type literal members are separated by semicolons.\nEnforces a trailing semicolon for multiline type literals.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "style",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "typedef": {
+    "description": "Requires type definitions to exist.",
+    "optionsDescription": "\nSeveral arguments may be optionally provided:\n\n* `\"call-signature\"` checks return type of functions.\n* `\"arrow-call-signature\"` checks return type of arrow functions.\n* `\"parameter\"` checks type specifier of function parameters for non-arrow functions.\n* `\"arrow-parameter\"` checks type specifier of function parameters for arrow functions.\n* `\"property-declaration\"` checks return types of interface properties.\n* `\"variable-declaration\"` checks non-binding variable declarations.\n* `\"member-variable-declaration\"` checks member variable declarations.\n* `\"object-destructuring\"` checks object destructuring declarations.\n* `\"array-destructuring\"` checks array destructuring declarations.",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "call-signature",
+          "arrow-call-signature",
+          "parameter",
+          "arrow-parameter",
+          "property-declaration",
+          "variable-declaration",
+          "member-variable-declaration",
+          "object-destructuring",
+          "array-destructuring"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 7
+    },
+    "optionExamples": [
+      [
+        true,
+        "call-signature",
+        "parameter",
+        "member-variable-declaration"
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "typedef-whitespace": {
+    "description": "Requires or disallows whitespace for type definitions.",
+    "descriptionDetails": "Determines if a space is required or not before the colon in a type specifier.",
+    "optionsDescription": "\nTwo arguments which are both objects.\nThe first argument specifies how much space should be to the _left_ of a typedef colon.\nThe second argument specifies how much space should be to the _right_ of a typedef colon.\nEach key should have a value of `\"onespace\"`, `\"space\"` or `\"nospace\"`.\nPossible keys are:\n\n* `\"call-signature\"` checks return type of functions.\n* `\"index-signature\"` checks index type specifier of indexers.\n* `\"parameter\"` checks function parameters.\n* `\"property-declaration\"` checks object property declarations.\n* `\"variable-declaration\"` checks variable declaration.",
+    "options": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "call-signature": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "index-signature": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "parameter": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "property-declaration": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "variable-declaration": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "call-signature": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "index-signature": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "parameter": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "property-declaration": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            },
+            "variable-declaration": {
+              "type": "string",
+              "enum": [
+                "nospace",
+                "onespace",
+                "space"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "additionalItems": false
+    },
+    "optionExamples": [
+      [
+        true,
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "hasFix": true,
+    "source": "tslint"
+  },
+  "typeof-compare": {
+    "description": "Makes sure result of `typeof` is compared to correct string values",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "deprecationMessage": "",
+    "source": "tslint"
+  },
+  "underscore-consistent-invocation": {
+    "type": "maintainability",
+    "description": "Enforce a consistent usage of the _ functions",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Low",
+    "level": "Opportunity for Excellence",
+    "group": "Clarity",
+    "commonWeaknessEnumeration": "398, 710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "unified-signatures": {
+    "description": "Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "typescript",
+    "typescriptOnly": true,
+    "source": "tslint"
+  },
+  "use-default-type-parameter": {
+    "description": "Warns if an explicitly specified type argument is the default for that type parameter.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      "true"
+    ],
+    "type": "functionality",
+    "typescriptOnly": true,
+    "requiresTypeInfo": true,
+    "source": "tslint"
+  },
+  "use-isnan": {
+    "description": "Enforces use of the `isNaN()` function to check for NaN references instead of a comparison to the `NaN` constant.",
+    "rationale": "\nSince `NaN !== NaN`, comparisons with regular operators will produce unexpected results.\nSo, instead of `if (myVar === NaN)`, do `if (isNaN(myVar))`.",
+    "optionsDescription": "Not configurable.",
+    "options": null,
+    "optionExamples": [
+      true
+    ],
+    "type": "functionality",
+    "typescriptOnly": false,
+    "source": "tslint",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:use-isnan"
+    ]
+  },
+  "use-named-parameter": {
+    "type": "maintainability",
+    "description": "Do not reference the arguments object by numerical index; instead, use a named parameter.",
+    "options": null,
+    "optionsDescription": "",
+    "typescriptOnly": true,
+    "issueClass": "Non-SDL",
+    "issueType": "Warning",
+    "severity": "Important",
+    "level": "Opportunity for Excellence",
+    "group": "Correctness",
+    "commonWeaknessEnumeration": "710",
+    "source": "tslint-microsoft-contrib"
+  },
+  "valid-jsdoc": {
+    "hasFix": false,
+    "description": "enforce valid JSDoc comments",
+    "rationale": "\n[JSDoc](http://usejsdoc.org/) generates application programming interface (API) documentation\nfrom specially-formatted comments in JavaScript code. So does [typedoc](http://typedoc.org/).\n\nIf comments are invalid because of typing mistakes, then documentation will be incomplete.\n\nIf comments are inconsistent because they are not updated when function definitions are\nmodified, then readers might become confused.\n",
+    "optionsDescription": "\nThis rule has an object option:\n\n* `\"prefer\"` enforces consistent documentation tags specified by an object whose properties\n               mean instead of key use value (for example, `\"return\": \"returns\"` means\n               instead of `@return` use `@returns`)\n* `\"preferType\"` enforces consistent type strings specified by an object whose properties\n                   mean instead of key use value (for example, `\"object\": \"Object\"` means\n                   instead of `object` use `Object`)\n* `\"requireReturn\"` requires a return tag:\n  * `true` (default) *even if* the function or method does not have a return statement\n             (this option value does not apply to constructors)\n  * `false` *if and only if* the function or method has a return statement (this option\n              value does apply to constructors)\n* `\"requireParamType\"`: `false` allows missing type in param tags\n* `\"requireReturnType\"`: `false` allows missing type in return tags\n* `\"matchDescription\"` specifies (as a string) a regular expression to match the description\n                         in each JSDoc comment (for example, `\".+\"` requires a description;\n                         this option does not apply to descriptions in parameter or return\n                         tags)\n* `\"requireParamDescription\"`: `false` allows missing description in parameter tags\n* `\"requireReturnDescription\"`: `false` allows missing description in return tags\n",
+    "options": {
+      "type": "object",
+      "properties": {
+        "prefer": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "preferType": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "requireReturn": {
+          "type": "boolean"
+        },
+        "requireParamDescription": {
+          "type": "boolean"
+        },
+        "requireReturnDescription": {
+          "type": "boolean"
+        },
+        "matchDescription": {
+          "type": "string"
+        },
+        "requireParamType": {
+          "type": "boolean"
+        },
+        "requireReturnType": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionExamples": [
+      "\n\"valid-jsdoc\": [true]\n",
+      "\n\"valid-jsdoc\": [true, {\n  \"prefer\": {\n    \"return\": \"returns\"\n  },\n  \"requireReturn\": false,\n  \"requireParamDescription\": true,\n  \"requireReturnDescription\": true,\n  \"matchDescription\": \"^[A-Z][A-Za-z0-9\\\\s]*[.]$\"\n}]\n"
+    ],
+    "typescriptOnly": false,
+    "type": "maintainability",
+    "source": "tslint-eslint-rules"
+  },
+  "valid-typeof": {
+    "source": "tslint-eslint-rules",
+    "sameName": [
+      "./node_modules/tslint-microsoft-contrib:valid-typeof"
+    ]
+  },
+  "variable-name": {
+    "description": "Checks variable names for various errors.",
+    "optionsDescription": "\nFive arguments may be optionally provided:\n\n* `\"check-format\"`: allows only lowerCamelCased or UPPER_CASED variable names\n  * `\"allow-leading-underscore\"` allows underscores at the beginning (only has an effect if \"check-format\" specified)\n  * `\"allow-trailing-underscore\"` allows underscores at the end. (only has an effect if \"check-format\" specified)\n  * `\"allow-pascal-case\"` allows PascalCase in addition to lowerCamelCase.\n  * `\"allow-snake-case\"` allows snake_case in addition to lowerCamelCase.\n* `\"ban-keywords\"`: disallows the use of certain TypeScript keywords as variable or parameter names.\n  * These are: `any`, `Number`, `number`, `String`, `string`, `Boolean`, `boolean`, `Undefined`, `undefined`",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "check-format",
+          "allow-leading-underscore",
+          "allow-trailing-underscore",
+          "allow-pascal-case",
+          "allow-snake-case",
+          "ban-keywords"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 5
+    },
+    "optionExamples": [
+      [
+        true,
+        "ban-keywords",
+        "check-format",
+        "allow-leading-underscore"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "source": "tslint"
+  },
+  "whitespace": {
+    "description": "Enforces whitespace style conventions.",
+    "rationale": "Helps maintain a readable, consistent style in your codebase.",
+    "optionsDescription": "\nTen arguments may be optionally provided:\n\n* `\"check-branch\"` checks branching statements (`if`/`else`/`for`/`while`) are followed by whitespace.\n* `\"check-decl\"`checks that variable declarations have whitespace around the equals token.\n* `\"check-operator\"` checks for whitespace around operator tokens.\n* `\"check-module\"` checks for whitespace in import & export statements.\n* `\"check-separator\"` checks for whitespace after separator tokens (`,`/`;`).\n* `\"check-rest-spread\"` checks that there is no whitespace after rest/spread operator (`...`).\n* `\"check-type\"` checks for whitespace before a variable type specification.\n* `\"check-typecast\"` checks for whitespace between a typecast and its target.\n* `\"check-type-operator\"` checks for whitespace between type operators `|` and `&`.\n* `\"check-preblock\"` checks for whitespace before the opening brace of a block",
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "check-branch",
+          "check-decl",
+          "check-operator",
+          "check-module",
+          "check-separator",
+          "check-rest-spread",
+          "check-type",
+          "check-typecast",
+          "check-type-operator",
+          "check-preblock"
+        ]
+      },
+      "minLength": 0,
+      "maxLength": 10
+    },
+    "optionExamples": [
+      [
+        true,
+        "check-branch",
+        "check-operator",
+        "check-typecast"
+      ]
+    ],
+    "type": "style",
+    "typescriptOnly": false,
+    "hasFix": true,
+    "source": "tslint"
+  }
+}


### PR DESCRIPTION
To be able to reason about rule changes between upgrades I created https://github.com/karfau/tslint-report
Adding the generated reports to the repo allows to compare after an upgrade.

The reports added in this PR are actually generated from inside our main repository which currently uses [bettermarks/bm-tslint-rules#v0.0.8](https://github.com/bettermarks/bm-tslint-rules/releases/tag/v0.0.8)

I'm adding these reports, so in future PRs we can regenerate the reports and see what changes.