### PR TITLE
no-unused-expression-chai: switching back to the official repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -448,7 +448,9 @@
       }
     },
     "tslint-no-unused-expression-chai": {
-      "version": "github:karfau/tslint-no-unused-expression-chai#4586f08851d2a105b4e38257cff68fdeac897cee",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.1.3.tgz",
+      "integrity": "sha512-dNnAc2f4M0KvyPNtEgiW2lS1LIss9Rg+cYI6x9J2NQeNt7FUI/5UfOJvsOERyog+D5+YeEzhkQSfSc4H7KMZLA==",
       "requires": {
         "tsutils": "2.21.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",
@@ -32,7 +32,7 @@
     "tslint": "5.8.0",
     "tslint-eslint-rules": "4.1.1",
     "tslint-microsoft-contrib": "5.0.3",
-    "tslint-no-unused-expression-chai": "github:karfau/tslint-no-unused-expression-chai#4586f08",
+    "tslint-no-unused-expression-chai": "~0.1.3",
     "tslint-react": "3.4.0"
   },
   "devDependencies": {

--- a/tslint.json
+++ b/tslint.json
@@ -143,7 +143,8 @@
     "no-unnecessary-class": true,
     "no-unused-expression-chai": [ // "no-unused-expression" is disabled by extending config with the same name
       true,
-      "allow-fast-null-checks"
+      "allow-fast-null-checks",
+      "should"
     ],
     "no-unused-variable": [
       true,

--- a/tslint.report.active.json
+++ b/tslint.report.active.json
@@ -654,7 +654,8 @@
   },
   "no-unused-expression-chai": {
     "ruleArguments": [
-      "allow-fast-null-checks"
+      "allow-fast-null-checks",
+      "should"
     ],
     "ruleSeverity": "error",
     "source": "tslint-no-unused-expression-chai"

--- a/tslint.report.available.json
+++ b/tslint.report.available.json
@@ -3570,7 +3570,7 @@
     "description": "Disallows unused expression statements.",
     "descriptionDetails": "\nUnused expressions are expression statements which are not assignments or function calls\n(and thus usually no-ops).",
     "rationale": "\nDetects potential errors where an assignment or function call was intended.",
-    "optionsDescription": "\nTwo arguments may be optionally provided:\n\n* `allow-fast-null-checks` allows to use logical operators to perform fast null checks and perform\nmethod or function calls for side effects (e.g. `e && e.preventDefault()`).\n* `allow-new` allows 'new' expressions for side effects (e.g. `new ModifyGlobalState();`.\n* `allow-tagged-template` allows tagged templates for side effects (e.g. `this.add\\`foo\\`;`.",
+    "optionsDescription": "\nThe following arguments may be optionally provided:\n\n* `allow-fast-null-checks` allows to use logical operators to perform fast null checks\n  and perform method or function calls for side effects (e.g. `e && e.preventDefault()`).\n* `allow-new` allows 'new' expressions for side effects (e.g. `new ModifyGlobalState();`.\n* `allow-tagged-template` allows tagged templates for side effects\n  (e.g. `this.add\\`foo\\`;`).\n* `should` supports chai assertions using `should` in addition to `expect`;`.\n",
     "options": {
       "type": "array",
       "items": {
@@ -3578,17 +3578,27 @@
         "enum": [
           "allow-fast-null-checks",
           "allow-new",
-          "allow-tagged-template"
+          "allow-tagged-template",
+          "should"
         ]
       },
       "minLength": 0,
-      "maxLength": 3
+      "maxLength": 4
     },
     "optionExamples": [
       true,
       [
         true,
         "allow-fast-null-checks"
+      ],
+      [
+        true,
+        "should"
+      ],
+      [
+        true,
+        "allow-fast-null-checks",
+        "should"
       ]
     ],
     "type": "functionality",

--- a/tslint.report.sources.json
+++ b/tslint.report.sources.json
@@ -41,8 +41,8 @@
     }
   },
   "./node_modules/tslint-no-unused-expression-chai": {
-    "_from": "github:karfau/tslint-no-unused-expression-chai#e04be1f",
-    "_resolved": "github:karfau/tslint-no-unused-expression-chai#e04be1f59dca677928b3c0dac1d5637d4746ae26",
+    "_from": "tslint-no-unused-expression-chai@~0.1.3",
+    "_resolved": "https://registry.npmjs.org/tslint-no-unused-expression-chai/-/tslint-no-unused-expression-chai-0.1.3.tgz",
     "bugs": {
       "url": "https://github.com/kwonoj/tslint-no-unused-expression-chai/issues"
     },


### PR DESCRIPTION
latest version contains the should support behind additional option (kwonoj/tslint-no-unused-expression-chai#14)

