### PR TITLE
bringing back no-unused-variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",

--- a/tslint.json
+++ b/tslint.json
@@ -146,6 +146,13 @@
       "allow-fast-null-checks",
       "should"
     ],
+    "no-unused-variable": [
+      // in agreement with https://github.com/palantir/tslint/issues/4100
+      // this ruleset doesn't force people to switch to compile error
+      // for getting rid of unused things, this currently means
+      // paying the price of the deprecation warning
+      true
+    ],
     "no-use-before-declare": true,
     "no-useless-files": true,
     "no-void-expression": false,

--- a/tslint.report.active.json
+++ b/tslint.report.active.json
@@ -662,6 +662,13 @@
     "ruleSeverity": "error",
     "source": "tslint-no-unused-expression-chai"
   },
+  "no-unused-variable": {
+    "deprecated": "Since TypeScript 2.9. Please use the built-in compiler checks instead.",
+    "documentation": "https://palantir.github.io/tslint/rules/no-unused-variable",
+    "hasFix": true,
+    "ruleSeverity": "error",
+    "source": "tslint"
+  },
   "no-use-before-declare": {
     "documentation": "https://palantir.github.io/tslint/rules/no-use-before-declare",
     "ruleSeverity": "error",


### PR DESCRIPTION
in agreement with https://github.com/palantir/tslint/issues/4100
this ruleset doesn't force people to switch to compile error for getting rid of unused things,
this currently means paying the price of the deprecation warning

Rule docs: https://palantir.github.io/tslint/rules/no-unused-variable/

I dropped the earlier rule argument since it was not fitting into the supported arguments.

comparison to last version that contained it: 
https://github.com/bettermarks/bm-tslint-rules/compare/c9bf1ab813fce1ba4a6da18f6250f4bdc24b9178...f3b3eaf