### PR TITLE
Preventing upgrades to npm next versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
   ],
   "bumpVersion": "patch",
   "prConcurrentLimit": 2,
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
+  "respectLatest": true
 }


### PR DESCRIPTION
PR #41 points to a pre release, would like to prevent those PRs

https://renovatebot.com/docs/presets-default/#respectlatest