### PR TITLE
only use semicolon rule from tslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",

--- a/tslint.json
+++ b/tslint.json
@@ -111,7 +111,7 @@
     "no-eval": true,
     "no-ex-assign": true,
     "no-extra-boolean-cast": true,
-    "no-extra-semi": true,
+    "no-extra-semi": false,
     "no-http-string": false,
     "no-increment-decrement": false,
     "no-inferrable-types": true,
@@ -141,6 +141,7 @@
     "no-trailing-whitespace": true,
     "no-unsafe-any": false,
     "no-unnecessary-class": true,
+    "no-unnecessary-semicolons": false,
     "no-unused-expression-chai": [ // "no-unused-expression" is disabled by extending config with the same name
       true,
       "allow-fast-null-checks",

--- a/tslint.report.active.json
+++ b/tslint.report.active.json
@@ -380,11 +380,6 @@
     "ruleSeverity": "error",
     "source": "tslint-eslint-rules"
   },
-  "no-extra-semi": {
-    "documentation": "https://eslint.org/docs/rules/no-extra-semi",
-    "ruleSeverity": "error",
-    "source": "tslint-eslint-rules"
-  },
   "no-floating-promises": {
     "documentation": "https://palantir.github.io/tslint/rules/no-floating-promises",
     "ruleSeverity": "error",
@@ -632,11 +627,6 @@
     "hasFix": true,
     "ruleSeverity": "error",
     "source": "tslint"
-  },
-  "no-unnecessary-semicolons": {
-    "documentation": "https://github.com/Microsoft/tslint-microsoft-contrib#supported-rules",
-    "ruleSeverity": "error",
-    "source": "tslint-microsoft-contrib"
   },
   "no-unnecessary-type-assertion": {
     "documentation": "https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion",


### PR DESCRIPTION
- it is most configurable
- it has better docs
- disabling equivalent rules from [tslint-eslint-rules](https://eslint.org/docs/rules/no-extra-semi) and [tslint-microsoft-contrib](https://github.com/Microsoft/tslint-microsoft-contrib#supported-rules)