### PR TITLE
renovate: no more digest updates for tslint-report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bm-tslint-rules",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "default tslint rules to use for projects using typescript",
   "repository": "https://github.com/bettermarks/bm-tslint-rules",
   "bugs": "https://github.com/bettermarks/bm-tslint-rules/issues",

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,11 @@
   "bumpVersion": "patch",
   "prConcurrentLimit": 2,
   "prHourlyLimit": 0,
-  "respectLatest": true
+  "respectLatest": true,
+  "packageRules": [
+    {
+      "packageNames": ["tslint-report"],
+      "extends": [":disableDigestUpdates"]
+    }
+  ]
 }


### PR DESCRIPTION
Will always be a manual update (maybe it could even be removed from the dependencies and used via `npx`).
